### PR TITLE
Fixes for vs2017 / VS2015

### DIFF
--- a/src/Core/CoreLib/AdditionalCompilerOptions.txt
+++ b/src/Core/CoreLib/AdditionalCompilerOptions.txt
@@ -1,0 +1,1 @@
+/runtimemetadataversion:v4.0.30319

--- a/src/Core/CoreLib/CoreLib.csproj
+++ b/src/Core/CoreLib/CoreLib.csproj
@@ -1,16 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{36D4B098-A21C-4725-ACD3-400922885F38}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System</RootNamespace>
     <AssemblyName>mscorlib</AssemblyName>
-    <NoStdLib>True</NoStdLib>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\ScriptSharp.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -19,6 +18,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CompilerResponseFile>AdditionalCompilerOptions.txt</CompilerResponseFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
@@ -29,7 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\..\bin\Debug\mscorlib.xml</DocumentationFile>
-    <NoWarn>1591, 0661, 0660</NoWarn>
+    <NoWarn>1591, 0626, 0824, 0660, 0661</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -40,8 +40,16 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591, 0661, 0660</NoWarn>
+    <NoWarn>1591, 0626, 0824, 0660, 0661</NoWarn>
     <DocumentationFile>..\..\..\bin\Release\mscorlib.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoStdLib>True</NoStdLib>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <AdditionalExplicitAssemblyReferences />
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Collections\ArrayReduceCallback.cs" />
@@ -79,6 +87,7 @@
     <Compile Include="ComponentModel\Observable.cs" />
     <Compile Include="Export.cs" />
     <Compile Include="Diagnostics\SyntaxValidationAttribute.cs" />
+    <Compile Include="NotImplementedException.cs" />
     <Compile Include="Threading\Deferred.cs" />
     <Compile Include="Threading\TaskStatus.cs" />
     <Compile Include="Threading\Task.cs" />
@@ -157,7 +166,9 @@
     <Compile Include="Testing\TestEngine.cs" />
     <Compile Include="Testing\TestClass.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="AdditionalCompilerOptions.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)version.targets" Condition="Exists('$(SolutionDir)version.targets')" />
 </Project>

--- a/src/Core/CoreLib/CoreLib.csproj
+++ b/src/Core/CoreLib/CoreLib.csproj
@@ -18,7 +18,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CompilerResponseFile>AdditionalCompilerOptions.txt</CompilerResponseFile>
+    <CompilerResponseFile Condition=" $(MSBuildToolsVersion) >= 13.0 ">AdditionalCompilerOptions.txt</CompilerResponseFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>

--- a/src/Core/CoreLib/Exception.cs
+++ b/src/Core/CoreLib/Exception.cs
@@ -14,7 +14,7 @@ namespace System {
     [ScriptIgnoreNamespace]
     [ScriptImport]
     [ScriptName("Error")]
-    public sealed class Exception {
+    public class Exception {
 
         public Exception(string message) {
         }

--- a/src/Core/CoreLib/NotImplementedException.cs
+++ b/src/Core/CoreLib/NotImplementedException.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace System
+{
+    [ScriptIgnoreNamespace]
+    [ScriptImport]
+    [ScriptName("Error")]
+    public class NotImplementedException : Exception
+    {
+        public NotImplementedException() 
+            : base(null)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixing an issue in the mscorlib where the roslyn compiler would attempt to create a NotImplementedException symbol. The Scriptsharp mscorlib was missing this type which was causing code provider errors in VS2015 and above. 