### PR TITLE
Updated Xml Api output names

### DIFF
--- a/src/Core/CoreLib/Object.cs
+++ b/src/Core/CoreLib/Object.cs
@@ -14,6 +14,8 @@ namespace System {
     [ScriptImport]
     public class Object {
 
+        public const string NAME_DEFINITION = "Object";
+
         /// <summary>
         /// Retrieves the type associated with an object instance.
         /// </summary>

--- a/src/Libraries/Web/Xml/XmlAttribute.cs
+++ b/src/Libraries/Web/Xml/XmlAttribute.cs
@@ -9,6 +9,7 @@ namespace System.Xml {
 
     [ScriptIgnoreNamespace]
     [ScriptImport]
+    [ScriptName("Attr")]
     public sealed class XmlAttribute : XmlNode {
 
         internal XmlAttribute() {

--- a/src/Libraries/Web/Xml/XmlNamedNodeMap.cs
+++ b/src/Libraries/Web/Xml/XmlNamedNodeMap.cs
@@ -10,6 +10,7 @@ namespace System.Xml {
 
     [ScriptIgnoreNamespace]
     [ScriptImport]
+    [ScriptName("NamedNodeMap")]
     public sealed class XmlNamedNodeMap : IEnumerable {
 
         internal XmlNamedNodeMap() {

--- a/src/Libraries/Web/Xml/XmlNode.cs
+++ b/src/Libraries/Web/Xml/XmlNode.cs
@@ -9,6 +9,7 @@ namespace System.Xml {
 
     [ScriptIgnoreNamespace]
     [ScriptImport]
+    [ScriptName(Object.NAME_DEFINITION)]
     public class XmlNode {
 
         internal XmlNode() {

--- a/src/Libraries/Web/Xml/XmlNodeList.cs
+++ b/src/Libraries/Web/Xml/XmlNodeList.cs
@@ -10,6 +10,7 @@ namespace System.Xml {
 
     [ScriptIgnoreNamespace]
     [ScriptImport]
+    [ScriptName("NodeList")]
     public sealed class XmlNodeList : IEnumerable {
 
         internal XmlNodeList() {

--- a/src/Libraries/Web/Xml/XmlText.cs
+++ b/src/Libraries/Web/Xml/XmlText.cs
@@ -9,6 +9,7 @@ namespace System.Xml {
 
     [ScriptIgnoreNamespace]
     [ScriptImport]
+    [ScriptName(Object.NAME_DEFINITION)]
     public sealed class XmlText : XmlNode {
 
         internal XmlText() {


### PR DESCRIPTION
 - Added definition key for the object name which can be used in Api's to decorate the class as the object type (using ScriptName)
 - Added ScriptName attributes where applicable for the Xml Types