### PR TITLE
Adding compatibility for legacy OS like iOS 7-8 to support number formatting

### DIFF
--- a/src/Core/Scripts/Runtime/Format.js
+++ b/src/Core/Scripts/Runtime/Format.js
@@ -8,7 +8,7 @@ function _commaFormatNumber(number, groups, decimal, comma) {
     number = number.substr(0, decimalIndex);
   }
 
-  var negative = number.startsWith('-');
+  var negative = startsWith(number, '-');
   if (negative) {
     number = number.substr(1);
   }


### PR DESCRIPTION
String's startsWith is not available in many legacy OS like iOS 7/8 so it needs to use its own extension