### PR TITLE
Optimize ICollection iteration (enumerator -> for)

### DIFF
--- a/src/DSharp.Compiler.Tests/Source/Statement/Foreach/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Statement/Foreach/Baseline.txt
@@ -1,8 +1,6 @@
 "use strict";
 
-define('test', ['ss'], function(ss) {
-  var $global = this;
-
+var test = (function($global){
   // StatementTests.Set
 
   function Set() {
@@ -22,25 +20,37 @@ define('test', ['ss'], function(ss) {
     test: function(arg) {
       var items = [ 1, 2, 3 ];
       var sum = 0;
-      var $enum1 = ss.enumerate(items);
-      while ($enum1.moveNext()) {
-        var i = $enum1.current;
+      var $enum1 = (items);
+      for(var $enum1_index = 0; $enum1_index < $enum1.length; ++$enum1_index) {
+        var i = $enum1[$enum1_index];
+        sum += i;
+      }
+      sum = 0;
+      var $enum2 = (items);
+      for(var $enum2_index = 0; $enum2_index < $enum2.length; ++$enum2_index) {
+        var i = $enum2[$enum2_index];
+        sum += i;
+      }
+      sum = 0;
+      var $enum3 = ([1, 2, 3]);
+      for(var $enum3_index = 0; $enum3_index < $enum3.length; ++$enum3_index) {
+        var i = $enum3[$enum3_index];
         sum += i;
       }
       var d = {};
-      for (var $key2 in d) {
-        var entry = { key: $key2, value: d[$key2] };
+      for (var $key4 in d) {
+        var entry = { key: $key4, value: d[$key4] };
         var s = entry.key + ' = ' + entry.value;
       }
       var s = new Set();
-      var $enum3 = ss.enumerate(s);
-      while ($enum3.moveNext()) {
-        var o = $enum3.current;
+      var $enum5 = ss.enumerate(s);
+      while ($enum5.moveNext()) {
+        var o = $enum5.current;
         this._doStuff(o);
       }
-      var $dict4 = this._getDictionary();
-      for (var $key5 in $dict4) {
-        var entry = { key: $key5, value: $dict4[$key5] };
+      var $dict6 = this._getDictionary();
+      for (var $key7 in $dict6) {
+        var entry = { key: $key7, value: $dict6[$key7] };
         var s = entry.key + ' = ' + entry.value;
       }
     },
@@ -63,4 +73,4 @@ define('test', ['ss'], function(ss) {
 
 
   return $exports;
-});
+})(self);

--- a/src/DSharp.Compiler.Tests/Source/Statement/Foreach/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Statement/Foreach/Code.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 [assembly: ScriptAssembly("test")]
@@ -22,6 +23,20 @@ namespace StatementTests {
             int sum = 0;
 
             foreach (int i in items) {
+                sum += i;
+            }
+
+            sum = 0;
+
+            foreach (int i in (ICollection<int>)items)
+            {
+                sum += i;
+            }
+              
+            sum = 0;
+
+            foreach (int i in new List<int>(1, 2, 3))
+            {
                 sum += i;
             }
 

--- a/src/DSharp.Compiler.Tests/Source/Type/Enumerator/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Type/Enumerator/Baseline.txt
@@ -1,8 +1,6 @@
 "use strict";
 
-define('test', ['ss'], function(ss) {
-  var $global = this;
-
+var test = (function($global){
   // TypeTests.App1
 
   function App1() {
@@ -28,9 +26,9 @@ define('test', ['ss'], function(ss) {
       var a1 = ss.enumerate(a);
       a1 = ss.enumerate(b);
       a1 = ss.enumerate(s);
-      var $enum1 = ss.enumerate(s);
-      while ($enum1.moveNext()) {
-        var str = $enum1.current;
+      var $enum1 = (s);
+      for(var $enum1_index = 0; $enum1_index < $enum1.length; ++$enum1_index) {
+        var str = $enum1[$enum1_index];
         var s1 = str;
       }
       var app1;
@@ -51,4 +49,4 @@ define('test', ['ss'], function(ss) {
 
 
   return $exports;
-});
+})(self);

--- a/src/DSharp.Compiler/Extensions/TypeSymbolExtensions.cs
+++ b/src/DSharp.Compiler/Extensions/TypeSymbolExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DSharp.Compiler.ScriptModel.Symbols;
+
+namespace DSharp.Compiler.Extensions
+{
+    public static class TypeSymbolExtensions
+    {
+        internal static ICollection<InterfaceSymbol> GetInterfaces(this TypeSymbol symbol)
+        {
+            if (symbol is ClassSymbol classSymbol)
+            {
+                return classSymbol.Interfaces ?? Array.Empty<InterfaceSymbol>();
+            }
+
+            if (symbol is InterfaceSymbol interfaceSymbol)
+            {
+                var interfaces = new List<InterfaceSymbol> { interfaceSymbol };
+
+                if (interfaceSymbol.Interfaces != null)
+                {
+                    interfaces.AddRange(interfaceSymbol.Interfaces);
+                }
+
+                return interfaces;
+            }
+
+            return null;
+        }
+
+        internal static bool IsCollectionType(this TypeSymbol symbol)
+        {
+            var interfaces = symbol.GetInterfaces();
+
+            if (interfaces == null)
+            {
+                return false;
+            }
+
+            if (interfaces.Any(i => i.FullName.StartsWith("System.Collections") && i.FullGeneratedName == "ICollection"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/DSharp.Compiler/Generator/StatementGenerator.cs
+++ b/src/DSharp.Compiler/Generator/StatementGenerator.cs
@@ -159,6 +159,29 @@ namespace DSharp.Compiler.Generator
                 writer.Indent--;
                 writer.WriteLine("}");
             }
+            else if (statement.CollectionExpression.EvaluatedType.IsArray)
+            {
+                string dataSourceVariableName = statement.LoopVariable.GeneratedName;
+                string indexVariableName = dataSourceVariableName + "_index";
+
+                // var $$ = ({CollectionExpression});
+                writer.Write("var " + dataSourceVariableName + " = (");
+                ExpressionGenerator.GenerateExpression(generator, symbol, statement.CollectionExpression);
+                writer.WriteLine(");");
+
+                // for(var items_index = 0; items_index < items.length; ++items_index) {
+                writer.WriteLine("for(var " + indexVariableName + " = 0; " + indexVariableName + " < " + dataSourceVariableName + ".length; ++" + indexVariableName + ") {");
+
+                ++writer.Indent;
+
+                // var i = items[items_index];
+                writer.WriteLine("var " + statement.ItemVariable.GeneratedName + " = " + dataSourceVariableName + "[" + indexVariableName + "];");
+
+                GenerateStatement(generator, symbol, statement.Body);
+
+                --writer.Indent;
+                writer.WriteLine("}");
+            }
             else
             {
                 writer.Write("var ");

--- a/src/DSharp.Compiler/Importer/MetadataImporter.cs
+++ b/src/DSharp.Compiler/Importer/MetadataImporter.cs
@@ -811,11 +811,6 @@ namespace DSharp.Compiler.Importer
                     {
                         ((ClassSymbol) typeSymbol).SetExtenderClass(extendee);
                     }
-
-                    if (string.CompareOrdinal(scriptName, nameof(Array)) == 0)
-                    {
-                        typeSymbol.SetArray();
-                    }
                 }
             }
 
@@ -867,8 +862,18 @@ namespace DSharp.Compiler.Importer
                     typeSymbol.SetTransformedName(scriptName);
                 }
 
+                SetArrayTypeMetadata(type, typeSymbol, scriptName);
+
                 namespaceSymbol.AddType(typeSymbol);
                 importedTypes.Add(typeSymbol);
+            }
+        }
+
+        private void SetArrayTypeMetadata(TypeDefinition type, TypeSymbol symbol, string scriptName)
+        {
+            if (scriptName == nameof(Array))
+            {
+                symbol.SetArray();
             }
         }
 

--- a/src/DSharp.Compiler/ScriptModel/Symbols/TypeSymbol.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/TypeSymbol.cs
@@ -1,4 +1,4 @@
-// TypeSymbol.cs
+﻿// TypeSymbol.cs
 // Script#/Core/Compiler
 // This source code is subject to terms and conditions of the Apache License, Version 2.0.
 //
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using DSharp.Compiler.Extensions;
 
 namespace DSharp.Compiler.ScriptModel.Symbols
 {
@@ -106,7 +107,27 @@ namespace DSharp.Compiler.ScriptModel.Symbols
 
         public ICollection<string> Imports { get; private set; }
 
-        public bool IsArray { get; private set; }
+        private bool _isArray = false;
+
+        public bool IsArray
+        {
+            get
+            {
+                if (_isArray)
+                {
+                    return true;
+                }
+
+                if (this.IsCollectionType())
+                {
+                    SetArray(); // add to cache
+
+                    return true;
+                }
+
+                return false;
+            }
+        }
 
         public bool IsApplicationType { get; private set; }
 
@@ -221,7 +242,7 @@ namespace DSharp.Compiler.ScriptModel.Symbols
 
         public void SetArray()
         {
-            IsArray = true;
+            _isArray = true;
         }
 
         public void SetImports(ICollection<string> imports)

--- a/src/DSharp.Mscorlib/Array.cs
+++ b/src/DSharp.Mscorlib/Array.cs
@@ -8,10 +8,15 @@ namespace System
     [ScriptIgnoreNamespace]
     [ScriptImport]
     [ScriptName("Array")]
-    public sealed class Array : IEnumerable
+    public sealed class Array : ICollection
     {
         [ScriptField]
+        [ScriptName("length")]
         public extern int Length { get; }
+
+        [ScriptField]
+        [ScriptName("length")]
+        public extern int Count { get; }
 
         [ScriptField]
         public extern object this[int index] { get; set; }

--- a/src/DSharp.Mscorlib/Collections/ArrayList.cs
+++ b/src/DSharp.Mscorlib/Collections/ArrayList.cs
@@ -6,7 +6,7 @@ namespace System.Collections
     [ScriptIgnoreNamespace]
     [ScriptImport]
     [ScriptName("Array")]
-    public sealed class ArrayList : IEnumerable {
+    public sealed class ArrayList : ICollection {
 
         public ArrayList() { }
 

--- a/src/DSharp.Mscorlib/Collections/Collection.cs
+++ b/src/DSharp.Mscorlib/Collections/Collection.cs
@@ -7,7 +7,7 @@ namespace System.Collections.ObjectModel
     [ScriptIgnoreNamespace]
     [ScriptImport]
     [ScriptName("Array")]
-    public abstract class Collection<T> : IEnumerable, IEnumerable<T>, ICollection<T>
+    public abstract class Collection<T> : ICollection<T>, IEnumerable<T>, IEnumerable
     {
         public static implicit operator Array(Collection<T> collection) { return null; }
         public static implicit operator List<T>(Collection<T> collection) { return null; }


### PR DESCRIPTION
This is a POC of a simple compiler optimization.

`IEnumerable` is used to abstract a source of data of any kind (including generators). This forces the usage of the enumeration pattern for iterations, leaving us with a O(n) complexity for accessing data.

`ICollection` is quite similar, but it abstracts **in-memory** data structures (Array, List, etc). Knowing that the data is already in memory, we can use the `operator[]` to access data in a constant complexity O(1) (this really depends on the implementation, but applies to Arrays and Lists).

When a class implements `ICollection` or the resolved type from an Expression is `ICollection`, we can optimize every iteration (foreach) **from the enumerator pattern to a simple `for`** since we know that the data is already in memory represented as an Array in javascript.

The unit tests are self-explanatory 😄