### PR TITLE
Compiler Documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ You can even use DSharp to work against other existing frameworks and APIs such 
 
 ## Compatibility ##
 
-The current solution `DSharp.sln` is only compatible with .NET 4.6.1 and Visual Studio 2017 for Windows.
+The current solution `DSharp.sln` is compatible with .NET 4.0 and Visual Studio 2017 for Windows.
 
 ## Compiler Implementation ##
 

--- a/Readme.md
+++ b/Readme.md
@@ -8,11 +8,9 @@ Specifically, DSharp lets you leverage the experience of C# (intellisense, build
 
 You can even use DSharp to work against other existing frameworks and APIs such as jQuery, jQuery plugins and Knockout, and can be extended to work against other existing script.
 
-DSharp requires .NET 4.0 and Visual Studio 2012.
-
 ## Compatibility ##
 
-The current solution `DSharp.sln` is only compatible with Visual Studio 2017 for Windows.
+The current solution `DSharp.sln` is only compatible with .NET 4.6.1 and Visual Studio 2017 for Windows.
 
 ## Compiler Implementation ##
 

--- a/Readme.md
+++ b/Readme.md
@@ -10,9 +10,105 @@ You can even use DSharp to work against other existing frameworks and APIs such 
 
 DSharp requires .NET 4.0 and Visual Studio 2012.
 
+## Compatibility ##
+
+The current solution `DSharp.sln` is only compatible with Visual Studio 2017 for Windows.
+
+## Compiler Implementation ##
+
+- ### Core
+
+    - **Build:** Generators and Tasks for the build system
+
+    - **Compiler:** Compiler implementation
+
+      - Lexer: Converts source code into `Tokens`
+
+      - Parser: Converts `Tokens` into `ParseNodes`
+
+      - Validator: Compile-time conditions for the parser
+
+      - Importer: Extracts the `TypeSymbols` from the assemblies and generates `Metadata` for them
+        > f.e: create all MethodSymbols for a declared `ClassSymbol`
+
+      - Builder: Transforms `ParseNodes` into `Metadata`
+        > f.e: create a Expression tree from a node
+
+      - Generator: Transforms `Symbols` and `Metadata` into output (javascript)
+
+    - **Mscorlib:** Dummy interfaces and classes that emulate the original `mscorlib.dll`. Having the same signatures of the original mscorlib enables cross-compilation.
+
+    - **Scripts:** Javascript implementations of mscorlib. It mostly includes helper methods and class implementations. The compiler binds C# code to JS implementation by using `ScriptAttributes`.
+
+    - **Web:** Web-specific abstractions that can be used when targeting DSharp. This is an extension library and isn't available in normal C#.
+
+    - **Shell:** Shell utility for invoking the compiler.
+
+- ### SDK
+
+    - Crosscompilation for DSharp and NetStandard
+    - Support for modern `csproj` syntax
+
+- ### Tests
+
+    - **Framework:** Implementation of the JS test framework.
+    - **Compiler.Tests:** Tests for the compiler.
+
+## Writing Tests ##
+
+Testing the compiler is quite straightforward: define an input c# file `Code.cs` and the expected result in `Baseline.txt`. The test runner will compare the result with the expected one.
+
+In order to create a new  you need to:
+
+1. Create the test files `Code.cs` and `Baseline.txt` in a relevant subdirectory under the `Source` folder.
+2. Add your test to `CompilerTests.json` pointing to the right files. The categories represent subdirectories inside the `Source` folder.
+
+## Debugging ##
+
+There are two ways of debugging the project: debugging a test or a shell that invokes the compiler.
+
+### Prerequisites ###
+
+- #### Enable all Common Language Runtime Exceptions
+  This can be done under `Debug` -> `Windows` -> `Exception Settings (Ctrl+Alt+E)` and ticking all `Common Language Runtime Exceptions`.
+
+### Debugging a Test ###
+
+Debugging a test is currently non-deterministic (it works depending on the computer, and it may display some artifacts on Visual Studio) but it's worth trying. This is due to xUnit runtime confusing Visual Studio.
+
+In order to debug a test you need to:
+
+1. Rebuild All
+2. In the test explorer, `Right Click` -> `Debug Selected Tests`
+
+### Debugging the Shell ###
+
+Debugging the Shell requires a bit of configuration: setting up the arguments for the invokation.
+
+In order to debug the shell you need to:
+
+1. Rebuild All
+2. In the `Core/DSharp.Shell` project, `Right Click` -> `Properties` -> `Debug` -> `Application arguments` and set the following:
+
+    ```
+    /ref:C:\Working\dsharp\src\DSharp.Mscorlib\bin\Debug\net461\DSharp.Mscorlib.dll
+    /out:out.js
+    C:\Working\dsharp\src\DSharp.Compiler.Tests\Source\Mscorlib\DateTime\Code.cs
+    ```
+    > update the paths to match the ones in your pc
+3. F5 in debug mode
+
+## Useful Links ##
+
+- ### mscorlib
+  Being compliant with latest implementations of `mscorlib` is extremely important for cross-compiling. These can be checked in the following links:
+
+  - [Source Dot Net](https://source.dot.net): Source reference with nice search and navigation
+  - [GitHub Project](https://github.com/dotnet/coreclr/tree/master/src/System.Private.CoreLib): Latests previews
+
 ### Credits ###
 
-DSharp is a fork of the excellent Script#  project.
+DSharp is a fork of the Script# project.
 
 ### License ###
 Copyright (c) 2015, DSharp Project.

--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ In order to debug the shell you need to:
 1. Rebuild All
 2. In the `Core/DSharp.Shell` project, `Right Click` -> `Properties` -> `Debug` -> `Application arguments` and set the following:
 
-    ```
+    ```console
     /ref:C:\Working\dsharp\src\DSharp.Mscorlib\bin\Debug\net461\DSharp.Mscorlib.dll
     /out:out.js
     C:\Working\dsharp\src\DSharp.Compiler.Tests\Source\Mscorlib\DateTime\Code.cs
@@ -101,9 +101,10 @@ In order to debug the shell you need to:
 - ### mscorlib
   Being compliant with latest implementations of `mscorlib` is extremely important for cross-compiling. These can be checked in the following links:
 
-  - [Source Dot Net](https://source.dot.net): Source reference with nice search and navigation
-  - [GitHub Project](https://github.com/dotnet/coreclr/tree/master/src/System.Private.CoreLib): Latests previews for NET Core
-  - [Net Standard GitHub](https://github.com/dotnet/standard)
+  - [Reference Source](https://referencesource.microsoft.com/): Official source reference from Microsoft with nice search and navigation
+  - [Source Dot Net](https://source.dot.net): Unofficial source reference for .NET Core
+  - [.NET Core GitHub](https://github.com/dotnet/coreclr/tree/master/src/System.Private.CoreLib): Latests previews for .NET Core
+  - [.NET Standard GitHub](https://github.com/dotnet/standard)
 
 ### Credits ###
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ The current solution `DSharp.sln` is only compatible with .NET 4.6.1 and Visual 
 
       - Validator: Compile-time conditions for the parser
 
-      - Importer: Extracts the `TypeSymbols` from the assemblies and generates `Metadata` for them
+      - Importer: Extracts the `TypeSymbols` from the assemblies (using Mono.Cecil) and generates `Metadata` for them
         > f.e: create all MethodSymbols for a declared `ClassSymbol`
 
       - Builder: Transforms `ParseNodes` into `Metadata`
@@ -102,7 +102,8 @@ In order to debug the shell you need to:
   Being compliant with latest implementations of `mscorlib` is extremely important for cross-compiling. These can be checked in the following links:
 
   - [Source Dot Net](https://source.dot.net): Source reference with nice search and navigation
-  - [GitHub Project](https://github.com/dotnet/coreclr/tree/master/src/System.Private.CoreLib): Latests previews
+  - [GitHub Project](https://github.com/dotnet/coreclr/tree/master/src/System.Private.CoreLib): Latests previews for NET Core
+  - [Net Standard GitHub](https://github.com/dotnet/standard)
 
 ### Credits ###
 


### PR DESCRIPTION
[Recommended link to check the diff](https://github.com/DerivcoIpswich/dsharp/pull/125/files?short_path=1e290ac#diff-1e290ac8433d555bce009b162cb869d0)

Add documentation about:
- project structure
- compiler implementation details
- testing
- debugging
- useful links