### PR TITLE
remove warnings on attribute

### DIFF
--- a/src/DSharp.Mscorlib/Attribute.cs
+++ b/src/DSharp.Mscorlib/Attribute.cs
@@ -5,6 +5,7 @@ namespace System
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
     [ScriptIgnore]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract class Attribute
     {
     }

--- a/src/DSharp.Mscorlib/Runtime/CompilerServices/TypeForwardedFromAttribute.cs
+++ b/src/DSharp.Mscorlib/Runtime/CompilerServices/TypeForwardedFromAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false, AllowMultiple = false)]
+    public sealed class TypeForwardedFromAttribute : Attribute
+    {
+        public TypeForwardedFromAttribute(string assemblyFullName) { }
+
+        public string AssemblyFullName { get; }
+    }
+}


### PR DESCRIPTION
This should do the trick to stop getting the warning regarding non-standard attribute but I was unable to test it