### PR TITLE
Fix Generic Inheritance Chains

### DIFF
--- a/src/DSharp.Compiler.Tests/Source/Expression/Array/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Array/Baseline.txt
@@ -38,6 +38,20 @@ define('test', ['ss'], function(ss) {
       var b3 = (words.indexOf('hi') >= 0);
       var newWords = words.slice(5, 7);
       var newWords2 = words.slice(5, 5 + arg);
+      var enumerator;
+      var count;
+      var x = [];
+      x.push(2);
+      enumerator = ss.enumerate(x);
+      count = x.length;
+      var a = [];
+      a.push(2);
+      enumerator = ss.enumerate(a);
+      count = a.length;
+      var c = [];
+      c.push(2);
+      enumerator = ss.enumerate(c);
+      count = c.length;
     }
   };
 

--- a/src/DSharp.Compiler.Tests/Source/Expression/Array/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Array/Code.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -41,6 +41,24 @@ namespace ExpressionTests {
             bool b3 = words.Contains("hi");
             string[] newWords = words.GetRange(5, 2);
             string[] newWords2 = words.GetRange(5, arg);
+
+            IEnumerator<int> enumerator;
+            int count;
+
+            IList<int> x = new List<int>();
+            x.Add(2);
+            enumerator = x.GetEnumerator();
+            count = x.Count;
+
+            IList a = new List<int>();
+            a.Add(2);
+            enumerator = a.GetEnumerator();
+            count = a.Count;
+
+            ICollection<int> c = new List<int>();
+            c.Add(2);
+            enumerator = c.GetEnumerator();
+            count = c.Count;
         }
     }
 }

--- a/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
@@ -895,10 +895,11 @@ namespace DSharp.Compiler.Compiler
 
             MemberExpression expression = new MemberExpression(objectExpression, memberSymbol);
 
-            if (memberSymbol.Type == SymbolType.Method &&
-                memberSymbol.AssociatedType.IsGeneric && memberSymbol.AssociatedType.GenericArguments == null)
+            if (memberSymbol.Type == SymbolType.Method
+                && memberSymbol.AssociatedType.IsGeneric
+                && memberSymbol.AssociatedType.GenericArguments == null
+                && node.RightChild.NodeType == ParseNodeType.GenericName)
             {
-                Debug.Assert(node.RightChild.NodeType == ParseNodeType.GenericName);
                 Debug.Assert(((GenericNameNode)node.RightChild).TypeArguments != null);
 
                 List<TypeSymbol> typeArgs = new List<TypeSymbol>();

--- a/src/DSharp.Compiler/ScriptModel/Symbols/SymbolSet.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/SymbolSet.cs
@@ -273,6 +273,7 @@ namespace DSharp.Compiler.ScriptModel.Symbols
             {
                 ClassSymbol genericClass = (ClassSymbol) templateType;
                 ClassSymbol instanceClass = new ClassSymbol(genericClass.Name, (NamespaceSymbol) genericClass.Parent);
+
                 instanceClass.SetInheritance(genericClass.BaseClass, genericClass.Interfaces);
                 instanceClass.SetImported(genericClass.Dependency);
 
@@ -311,6 +312,7 @@ namespace DSharp.Compiler.ScriptModel.Symbols
                 InterfaceSymbol instanceInterface =
                     new InterfaceSymbol(genericInterface.Name, (NamespaceSymbol) genericInterface.Parent);
 
+                instanceInterface.SetInheritance(genericInterface.Interfaces);
                 instanceInterface.SetImported(genericInterface.Dependency);
 
                 if (genericInterface.IgnoreNamespace)

--- a/src/DSharp.Mscorlib/Collections/Generic/List.cs
+++ b/src/DSharp.Mscorlib/Collections/Generic/List.cs
@@ -31,29 +31,29 @@ namespace System.Collections.Generic
         public extern void Add(T item);
 
         [ScriptName("push")]
-        public extern int Add(object value);
+        extern int IList.Add(object value);
 
         public extern bool Contains(T item);
 
-        public extern bool Contains(object value);
+        extern bool IList.Contains(object value);
 
         public extern void Clear();
 
-        public extern int IndexOf(object value);
-
         public extern int IndexOf(T item);
 
-        [DSharpScriptMemberName("remove")]
-        public extern void Remove(object value);
+        extern int IList.IndexOf(object value);
 
         [DSharpScriptMemberName("remove")]
         public extern bool Remove(T item);
 
+        [DSharpScriptMemberName("remove")]
+        extern void IList.Remove(object value);
+
         public extern void RemoveAt(int index);
 
-        public extern IEnumerator GetEnumerator();
+        public extern IEnumerator<T> GetEnumerator();
 
-        extern IEnumerator<T> IEnumerable<T>.GetEnumerator();
+        extern IEnumerator IEnumerable.GetEnumerator();
 
         public extern void Insert(int index, T item);
 


### PR DESCRIPTION
Fixes cases like:
- `IList<T>` : `ICollection<T>` : `IEnumerable<T>` : `IEnumerable`
- `class IEnumerable<T> : IEnumerable { new IEnumerator GetEnumerator(); }`