### PR TITLE
bugfix for generics

### DIFF
--- a/src/DSharp.Build/Tasks/ScriptCompilerTask.cs
+++ b/src/DSharp.Build/Tasks/ScriptCompilerTask.cs
@@ -192,10 +192,12 @@ namespace DSharp.Build.Tasks
             {
                 success = ExecuteCore(Sources, Resources);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Log.LogErrorFromException(e);
+                Log.LogErrorFromException(ex);
                 success = false;
+
+                throw;
             }
 
             return success;

--- a/src/DSharp.Compiler.Tests/DSharp.Compiler.Tests.csproj
+++ b/src/DSharp.Compiler.Tests/DSharp.Compiler.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Remove="Source\Expression\Members\Code.cs" />
     <Compile Remove="Source\Expression\New\Code.cs" />
     <Compile Remove="Source\Expression\Number\Code.cs" />
+    <Compile Remove="Source\Expression\ScriptIgnore\Code.cs" />
     <Compile Remove="Source\Expression\Script\Code.cs" />
     <Compile Remove="Source\Expression\String\Code.cs" />
     <Compile Remove="Source\Expression\Truthy\Code.cs" />
@@ -166,6 +167,7 @@
     <None Remove="Source\Expression\Members\Baseline.txt" />
     <None Remove="Source\Expression\New\Baseline.txt" />
     <None Remove="Source\Expression\Number\Baseline.txt" />
+    <None Remove="Source\Expression\ScriptIgnore\Baseline.txt" />
     <None Remove="Source\Expression\Script\Baseline.txt" />
     <None Remove="Source\Expression\String\Baseline.txt" />
     <None Remove="Source\Expression\Truthy\Baseline.txt" />
@@ -484,6 +486,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Source\Expression\Number\Code.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Source\Expression\ScriptIgnore\Baseline.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Source\Expression\ScriptIgnore\Code.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Source\Expression\Script\Baseline.txt">

--- a/src/DSharp.Compiler.Tests/DSharp.Compiler.Tests.csproj
+++ b/src/DSharp.Compiler.Tests/DSharp.Compiler.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Remove="Source\Basic\Flags\Code.cs" />
     <Compile Remove="Source\Basic\Guid\Code.cs" />
     <Compile Remove="Source\Basic\Includes\Code.cs" />
+    <Compile Remove="Source\Basic\GenericInheritance\Code.cs" />
     <Compile Remove="Source\Basic\Lists\Code.cs" />
     <Compile Remove="Source\Basic\Minimization\Code.cs" />
     <Compile Remove="Source\Basic\Minimization\Lib.cs" />
@@ -135,6 +136,7 @@
     <None Remove="Source\Basic\Includes\Post.js" />
     <None Remove="Source\Basic\Includes\Pre.js" />
     <None Remove="Source\Basic\Includes\SingleIncBaseline.txt" />
+    <None Remove="Source\Basic\GenericInheritance\Baseline.txt" />
     <None Remove="Source\Basic\Lists\Baseline.txt" />
     <None Remove="Source\Basic\Minimization\Baseline.txt" />
     <None Remove="Source\Basic\Minimization\Lib.bat" />
@@ -294,6 +296,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Source\Basic\Includes\SingleIncBaseline.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Source\Basic\GenericInheritance\Baseline.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Source\Basic\Lists\Baseline.txt">
@@ -774,6 +779,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Source\Basic\GenericInheritance\Code.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="Source\Basic\Resources\Strings1.Designer.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/DSharp.Compiler.Tests/DSharp.Compiler.Tests.csproj
+++ b/src/DSharp.Compiler.Tests/DSharp.Compiler.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Remove="Source\Expression\EnumToString\Code2.cs" />
     <Compile Remove="Source\Expression\Events\Code.cs" />
     <Compile Remove="Source\Expression\ExtensionMethods\Code.cs" />
+    <Compile Remove="Source\Expression\Generics2\Code.cs" />
     <Compile Remove="Source\Expression\Generics\Code.cs" />
     <Compile Remove="Source\Expression\GetType\Code.cs" />
     <Compile Remove="Source\Expression\InlineScript\Code.cs" />
@@ -155,6 +156,7 @@
     <None Remove="Source\Expression\EnumToString\NormalBaseline.txt" />
     <None Remove="Source\Expression\Events\Baseline.txt" />
     <None Remove="Source\Expression\ExtensionMethods\Baseline.txt" />
+    <None Remove="Source\Expression\Generics2\Baseline.txt" />
     <None Remove="Source\Expression\Generics\Baseline.txt" />
     <None Remove="Source\Expression\GetType\Baseline.txt" />
     <None Remove="Source\Expression\InlineScript\Baseline.txt" />
@@ -425,6 +427,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Source\Expression\ExtensionMethods\Code.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Source\Expression\Generics2\Baseline.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Source\Expression\Generics\Baseline.txt">
@@ -767,6 +772,9 @@
     <None Include="Source\Basic\Resources\Strings2.Designer.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="Source\Expression\Generics2\Code.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DSharp.Compiler.Tests/Source/Basic/GenericInheritance/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Basic/GenericInheritance/Baseline.txt
@@ -1,0 +1,28 @@
+﻿"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+  // BasicTests.IMyThing
+
+  function IMyThing() { }
+
+
+  // BasicTests.Wow
+
+  function Wow() {
+    Object.call(this);
+  }
+  var Wow$ = {
+
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      IMyThing: ss.defineInterface(IMyThing, [ss.IList]),
+      Wow: ss.defineClass(Wow, Wow$, [], Object)
+    });
+
+
+  return $exports;
+});

--- a/src/DSharp.Compiler.Tests/Source/Basic/GenericInheritance/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Basic/GenericInheritance/Code.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+
+[assembly: ScriptAssembly("test")]
+
+namespace BasicTests
+{
+    public interface IMyThing : IList<int>
+    {
+    }
+
+    public class Wow : KeyValuePair<int, string>
+    {
+    }
+}

--- a/src/DSharp.Compiler.Tests/Source/Basic/Lists/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Basic/Lists/Baseline.txt
@@ -10,7 +10,7 @@ define('test', ['ss'], function(ss) {
     list.push('one');
     list.push('two', 'three');
     var readOnlyList = list;
-    var array = list;
+    var array = ss.toArray(list);
   }
   var PublicClass$ = {
 

--- a/src/DSharp.Compiler.Tests/Source/CompilerTests.json
+++ b/src/DSharp.Compiler.Tests/Source/CompilerTests.json
@@ -206,6 +206,12 @@
         "References": [ "DSharp.Web.dll" ]
       },
       {
+        "Name": "Generics2",
+        "SourceFiles": [ "Code.cs" ],
+        "ComparisonFile": "Baseline.txt",
+        "References": [ ]
+      },
+      {
         "Name": "GetType",
         "SourceFiles": [ "Code.cs" ],
         "ComparisonFile": "Baseline.txt"

--- a/src/DSharp.Compiler.Tests/Source/CompilerTests.json
+++ b/src/DSharp.Compiler.Tests/Source/CompilerTests.json
@@ -209,7 +209,7 @@
         "Name": "Generics2",
         "SourceFiles": [ "Code.cs" ],
         "ComparisonFile": "Baseline.txt",
-        "References": [ ]
+        "References": []
       },
       {
         "Name": "GetType",
@@ -253,6 +253,11 @@
       },
       {
         "Name": "Script",
+        "SourceFiles": [ "Code.cs" ],
+        "ComparisonFile": "Baseline.txt"
+      },
+      {
+        "Name": "ScriptIgnore",
         "SourceFiles": [ "Code.cs" ],
         "ComparisonFile": "Baseline.txt"
       },

--- a/src/DSharp.Compiler.Tests/Source/CompilerTests.json
+++ b/src/DSharp.Compiler.Tests/Source/CompilerTests.json
@@ -93,6 +93,11 @@
         "ComparisonFile": "MultipleIncBaseline.txt"
       },
       {
+        "Name": "GenericInheritance",
+        "SourceFiles": [ "Code.cs" ],
+        "ComparisonFile": "Baseline.txt"
+      },
+      {
         "Name": "Default_Loader",
         "SourceFolder": "Simple",
         "SourceFiles": [ "Code.cs" ],

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Baseline.txt
@@ -1,0 +1,49 @@
+"use strict";
+
+define('g_b4bdbc8e390b4f5c8e02af2037e648c6', ['ss'], function(ss) {
+  var $global = this;
+  // ExpressionTests.Program
+
+  function Program() {
+  }
+  var Program$ = {
+    main: function() {
+      this.AAAAA(new DisposeMe(), new DisposeMe());
+    },
+    noParameters: function() {
+    },
+    noParametersConstrained: function(x) {
+      var t = T;
+      x.dispose();
+    },
+    inParameter: function(inGenericParameter) {
+      return inGenericParameter;
+    },
+    AAAAA: function(a1, a2) {
+      a1.dispose();
+      a2.main();
+      a2.dispose();
+    }
+  };
+
+
+  // ExpressionTests.DisposeMe
+
+  function DisposeMe() {
+    Program.call(this);
+  }
+  var DisposeMe$ = {
+    dispose: function() {
+    }
+  };
+
+
+  var $exports = ss.module('g_b4bdbc8e390b4f5c8e02af2037e648c6', null,
+    {
+      Program: ss.defineClass(Program, Program$, [], null),
+      DisposeMe: ss.defineClass(DisposeMe, DisposeMe$, [], Program, [ss.IDisposable])
+    });
+
+
+  return $exports;
+});

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Baseline.txt
@@ -25,8 +25,8 @@ define('test', ['ss'], function(ss) {
       this.inParameter(1234);
       this.inParameter(1234);
       this.inParameter(1234);
-      this.noParametersConstrained(new TestDisposableBase());
-      this.noParametersConstrained(new TestDisposableBase());
+      this.inParameterConstrained(new TestDisposableBase());
+      this.inParameterConstrained(new TestDisposableBase());
       this.complexInGenerics(new TestDisposableBase(), new TestDisposableBase());
     },
     noParameters: function() {

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Baseline.txt
@@ -1,47 +1,69 @@
 "use strict";
 
-define('g_b4bdbc8e390b4f5c8e02af2037e648c6', ['ss'], function(ss) {
+define('test', ['ss'], function(ss) {
   var $global = this;
+  // ExpressionTests.TestBase
+
+  function TestBase() {
+  }
+  var TestBase$ = {
+    performAction: function() {
+    }
+  };
+
+
   // ExpressionTests.Program
 
   function Program() {
   }
   var Program$ = {
     main: function() {
-      this.AAAAA(new DisposeMe(), new DisposeMe());
+      this.noParameters();
+      this.noParameters();
+      this.noParametersConstrained();
+      this.noParametersConstrained();
+      this.inParameter(1234);
+      this.inParameter(1234);
+      this.inParameter(1234);
+      this.noParametersConstrained(new TestDisposableBase());
+      this.noParametersConstrained(new TestDisposableBase());
+      this.complexInGenerics(new TestDisposableBase(), new TestDisposableBase());
     },
     noParameters: function() {
     },
-    noParametersConstrained: function(x) {
-      var t = T;
-      x.dispose();
+    noParametersConstrained: function() {
     },
     inParameter: function(inGenericParameter) {
       return inGenericParameter;
     },
-    AAAAA: function(a1, a2) {
+    inParameterConstrained: function(x) {
+      var xType = ss.typeOf(x);
+      x.dispose();
+    },
+    complexInGenerics: function(a1, a2) {
       a1.dispose();
-      a2.main();
+      a2.performAction();
       a2.dispose();
     }
   };
 
 
-  // ExpressionTests.DisposeMe
+  // ExpressionTests.TestDisposableBase
 
-  function DisposeMe() {
-    Program.call(this);
+  function TestDisposableBase() {
+    TestBase.call(this);
   }
-  var DisposeMe$ = {
+  var TestDisposableBase$ = {
     dispose: function() {
     }
   };
 
 
-  var $exports = ss.module('g_b4bdbc8e390b4f5c8e02af2037e648c6', null,
+  var $exports = ss.module('test', null,
     {
+      TestBase: ss.defineClass(TestBase, TestBase$, [], null),
       Program: ss.defineClass(Program, Program$, [], null),
-      DisposeMe: ss.defineClass(DisposeMe, DisposeMe$, [], Program, [ss.IDisposable])
+      TestDisposableBase: ss.defineClass(TestDisposableBase, TestDisposableBase$, [], TestBase, [ss.IDisposable])
     });
 
 

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Code.cs
@@ -31,8 +31,8 @@ namespace ExpressionTests
             InParameter(1234f);
             InParameter<double>(1234);
 
-            NoParametersConstrained<TestDisposableBase>(new TestDisposableBase());
-            NoParametersConstrained<IDisposable>(new TestDisposableBase());
+            InParameterConstrained<TestDisposableBase>(new TestDisposableBase());
+            InParameterConstrained<IDisposable>(new TestDisposableBase());
 
             ComplexInGenerics(new TestDisposableBase(), new TestDisposableBase());
         }

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Code.cs
@@ -1,29 +1,49 @@
 ﻿using System;
 using System.Collections;
+using System.Runtime.CompilerServices;
+using System.Serialization;
+
+[assembly: ScriptAssembly("test")]
 
 namespace ExpressionTests
 {
-    public class DisposeMe : Program, IDisposable { public void Dispose() { } }
+    public class TestBase
+    {
+        public void PerformAction() { }
+    }
+
+    public class TestDisposableBase : TestBase, IDisposable
+    {
+        public void Dispose() { }
+    }
 
     public class Program
     {
         public void Main()
         {
-            AAAAA(new DisposeMe(), new DisposeMe());
+            NoParameters<int>();
+            NoParameters<TestBase>();
+
+            NoParametersConstrained<TestDisposableBase>();
+            NoParametersConstrained<IDisposable>();
+
+            InParameter(1234);
+            InParameter(1234f);
+            InParameter<double>(1234);
+
+            NoParametersConstrained<TestDisposableBase>(new TestDisposableBase());
+            NoParametersConstrained<IDisposable>(new TestDisposableBase());
+
+            ComplexInGenerics(new TestDisposableBase(), new TestDisposableBase());
         }
 
         public void NoParameters<T>()
         {
         }
 
-        public void NoParametersConstrained<T>(T x)
+        public void NoParametersConstrained<T>()
             where T : IDisposable
         {
-            // this doesn't work
-            Type t = typeof(T);
-
-            // this works now
-            x.Dispose();
         }
 
         public object InParameter<T>(T inGenericParameter)
@@ -31,12 +51,21 @@ namespace ExpressionTests
             return inGenericParameter;
         }
 
-        public void AAAAA<T, Y>(T a1, Y a2)
+        public void InParameterConstrained<T>(T x)
             where T : IDisposable
-            where Y : Program, IDisposable
+        {
+            Type xType = x.GetType();
+
+            x.Dispose();
+        }
+
+        public void ComplexInGenerics<T, Y>(T a1, Y a2)
+            where T : IDisposable
+            where Y : TestBase, IDisposable
         {
             a1.Dispose();
-            a2.Main();
+
+            a2.PerformAction();
             a2.Dispose();
         }
     }

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics2/Code.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections;
+
+namespace ExpressionTests
+{
+    public class DisposeMe : Program, IDisposable { public void Dispose() { } }
+
+    public class Program
+    {
+        public void Main()
+        {
+            AAAAA(new DisposeMe(), new DisposeMe());
+        }
+
+        public void NoParameters<T>()
+        {
+        }
+
+        public void NoParametersConstrained<T>(T x)
+            where T : IDisposable
+        {
+            // this doesn't work
+            Type t = typeof(T);
+
+            // this works now
+            x.Dispose();
+        }
+
+        public object InParameter<T>(T inGenericParameter)
+        {
+            return inGenericParameter;
+        }
+
+        public void AAAAA<T, Y>(T a1, Y a2)
+            where T : IDisposable
+            where Y : Program, IDisposable
+        {
+            a1.Dispose();
+            a2.Main();
+            a2.Dispose();
+        }
+    }
+}

--- a/src/DSharp.Compiler.Tests/Source/Expression/ScriptIgnore/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/ScriptIgnore/Baseline.txt
@@ -1,0 +1,27 @@
+﻿"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+  // ExpressionTests.Program
+
+  function Program() {
+  }
+  var Program$ = {
+    main: function() {
+      var e1 = ss.enumerate(this);
+      var e2 = ss.enumerate((this));
+    },
+    getEnumerator: function() {
+      return null;
+    }
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      Program: ss.defineClass(Program, Program$, [], null, [ss.IEnumerable])
+    });
+
+
+  return $exports;
+});

--- a/src/DSharp.Compiler.Tests/Source/Expression/ScriptIgnore/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/ScriptIgnore/Code.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.CompilerServices;
+
+[assembly: ScriptAssembly("test")]
+
+namespace ExpressionTests
+{
+    public class Program : IEnumerable<int>
+    {
+        public void Main()
+        {
+            IEnumerator<int> e1 = this.GetEnumerator();
+            IEnumerator e2 = ((IEnumerable)this).GetEnumerator();
+        }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            return null;
+        }
+
+        [ScriptIgnore]
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return null;
+        }
+    }
+}

--- a/src/DSharp.Compiler.Tests/Source/Expression/ScriptIgnore/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/ScriptIgnore/Code.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 using System.Runtime.CompilerServices;
 
 [assembly: ScriptAssembly("test")]

--- a/src/DSharp.Compiler/CodeModel/Members/MethodDeclarationNode.cs
+++ b/src/DSharp.Compiler/CodeModel/Members/MethodDeclarationNode.cs
@@ -67,5 +67,9 @@ namespace DSharp.Compiler.CodeModel.Members
         public override ParseNode Type { get; }
 
         public bool IsExensionMethod => Parameters.FirstOrDefault()?.As<ParameterNode>().IsExtensionMethodTarget ?? false;
+
+        internal ParseNodeList TypeParameters => typeParameters;
+
+        internal ParseNodeList Constraints => constraints;
     }
 }

--- a/src/DSharp.Compiler/CodeModel/Types/TypeParameterConstraintNode.cs
+++ b/src/DSharp.Compiler/CodeModel/Types/TypeParameterConstraintNode.cs
@@ -1,4 +1,4 @@
-// TypeParameterConstraintNode.cs
+﻿// TypeParameterConstraintNode.cs
 // Script#/Core/Compiler
 // This source code is subject to terms and conditions of the Apache License, Version 2.0.
 //
@@ -22,5 +22,9 @@ namespace DSharp.Compiler.CodeModel.Types
             this.typeConstraints = typeConstraints;
             this.hasConstructorConstraint = hasConstructorConstraint;
         }
+
+        internal ParseNodeList TypeConstraints => typeConstraints;
+
+        internal AtomicNameNode TypeParameter => typeParameter;
     }
 }

--- a/src/DSharp.Compiler/CodeModel/Types/TypeParameterNode.cs
+++ b/src/DSharp.Compiler/CodeModel/Types/TypeParameterNode.cs
@@ -1,4 +1,4 @@
-// TypeParameterNode.cs
+﻿// TypeParameterNode.cs
 // Script#/Core/Compiler
 // This source code is subject to terms and conditions of the Apache License, Version 2.0.
 //
@@ -19,5 +19,7 @@ namespace DSharp.Compiler.CodeModel.Types
             this.attributes = attributes;
             this.name = name;
         }
+
+        internal AtomicNameNode NameNode => name;
     }
 }

--- a/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
@@ -774,7 +774,12 @@ namespace DSharp.Compiler.Compiler
                         throw new ExpressionBuildException($"Unable to resolve type '{typeName}' from symbol table.");
                     }
 
-                    return CreateExtensionMethodInvocationExpression(node, typeSymbol);
+                    Expression extensionMethodInvocation = CreateExtensionMethodInvocationExpression(node, typeSymbol);
+
+                    if (extensionMethodInvocation != null)
+                    {
+                        return extensionMethodInvocation;
+                    }
                 }
                 else if (node.LeftChild.Token is IdentifierToken identifier)
                 {
@@ -782,7 +787,12 @@ namespace DSharp.Compiler.Compiler
                     var token = parentMethod.Parameters.First().Token;
                     var typeNode = symbolSet.ResolveIntrinsicToken(token);
 
-                    return CreateExtensionMethodInvocationExpression(node, typeNode);
+                    Expression extensionMethodInvocation = CreateExtensionMethodInvocationExpression(node, typeNode);
+
+                    if (extensionMethodInvocation != null)
+                    {
+                        return extensionMethodInvocation;
+                    }
                 }
             }
 
@@ -976,6 +986,11 @@ namespace DSharp.Compiler.Compiler
         {
             string memberName = ((NameNode)node.RightChild).Name;
             MethodSymbol methodSymbol = symbolSet.ResolveExtensionMethodSymbol(typeToExtend.FullName, memberName);
+
+            if (methodSymbol == null)
+            {
+                return null;
+            }
 
             MethodExpression methodExpression = new MethodExpression(
                         new TypeExpression((TypeSymbol)methodSymbol.Parent, SymbolFilter.Public | SymbolFilter.StaticMembers),

--- a/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
@@ -1063,11 +1063,6 @@ namespace DSharp.Compiler.Compiler
         {
             string name = node.Name;
 
-            if (node.NodeType == ParseNodeType.GenericName)
-            {
-                name = name + "`" + ((GenericNameNode)node).TypeArguments.Count;
-            }
-
             // TODO: When inside a static method, we should only lookup static members
 
             Symbol symbol = symbolTable.FindSymbol(name, symbolContext, filter);
@@ -1825,6 +1820,10 @@ namespace DSharp.Compiler.Compiler
                 }
 
                 methodExpression = new MethodExpression(memberExpression.ObjectReference, method);
+
+                // iterate over the parameters. If the parameter is generic, then get args[i].EvaluatedType
+                // add it as SetGenericType and the SymbolTable
+                // (method symbol signature might need to be decorated)
             }
 
             if (methodExpression != null)
@@ -1838,7 +1837,10 @@ namespace DSharp.Compiler.Compiler
 
                 if (args != null)
                 {
-                    foreach (Expression paramExpr in args) methodExpression.AddParameterValue(paramExpr);
+                    foreach (Expression paramExpr in args)
+                    {
+                        methodExpression.AddParameterValue(paramExpr);
+                    }
                 }
 
                 if (isDelegateInvoke)

--- a/src/DSharp.Compiler/Compiler/MetadataBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/MetadataBuilder.cs
@@ -14,6 +14,7 @@ using DSharp.Compiler.CodeModel.Tokens;
 using DSharp.Compiler.CodeModel.Types;
 using DSharp.Compiler.Errors;
 using DSharp.Compiler.Extensions;
+using DSharp.Compiler.Importer;
 using DSharp.Compiler.ScriptModel.Symbols;
 
 namespace DSharp.Compiler.Compiler
@@ -695,6 +696,14 @@ namespace DSharp.Compiler.Compiler
 
             foreach (MemberNode member in typeNode.Members)
             {
+                var nodeAttributes = member.Attributes.Cast<AttributeNode>();
+
+                // skip symbol generation for members decorated with [ScriptIgnore]
+                if (nodeAttributes.Any(a => a.TypeName == DSharpStringResources.SCRIPT_IGNORE_ATTRIBUTE))
+                {
+                    continue;
+                }
+
                 MemberSymbol memberSymbol = null;
 
                 switch (member.NodeType)

--- a/src/DSharp.Compiler/Compiler/MetadataBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/MetadataBuilder.cs
@@ -806,11 +806,12 @@ namespace DSharp.Compiler.Compiler
                     {
                         List<GenericParameterSymbol> genericArguments = new List<GenericParameterSymbol>();
 
-                        int i = 0;
-                        foreach (TypeParameterNode genericParameter in methodNode.TypeParameters)
+                        for (var i = 0; i < methodNode.TypeParameters.Count; ++i)
                         {
+                            TypeParameterNode genericParameter = (TypeParameterNode)methodNode.TypeParameters[i];
+
                             GenericParameterSymbol arg =
-                                new GenericParameterSymbol(i++, genericParameter.NameNode.Name,
+                                new GenericParameterSymbol(i, genericParameter.NameNode.Name,
                                     /* typeArgument */ false,
                                     symbols.GlobalNamespace);
 

--- a/src/DSharp.Compiler/Compiler/MetadataBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/MetadataBuilder.cs
@@ -1276,8 +1276,16 @@ namespace DSharp.Compiler.Compiler
 
                 foreach (NameNode node in customTypeNode.BaseTypes)
                 {
+                    string nodeName = node.Name;
+
+                    if (node is GenericNameNode genericNameNode)
+                    {
+                        nodeName += $"`{genericNameNode.TypeArguments.Count}";
+                    }
+
                     TypeSymbol baseTypeSymbol =
-                        (TypeSymbol)symbolTable.FindSymbol(node.Name, classSymbol, SymbolFilter.Types);
+                        (TypeSymbol)symbolTable.FindSymbol(nodeName, classSymbol, SymbolFilter.Types);
+
                     Debug.Assert(baseTypeSymbol != null);
 
                     if (baseTypeSymbol.Type == SymbolType.Class)
@@ -1315,8 +1323,16 @@ namespace DSharp.Compiler.Compiler
 
                 foreach (NameNode node in customTypeNode.BaseTypes)
                 {
+                    string nodeName = node.Name;
+
+                    if (node is GenericNameNode genericNameNode)
+                    {
+                        nodeName += $"`{genericNameNode.TypeArguments.Count}";
+                    }
+
                     TypeSymbol baseTypeSymbol =
-                        (TypeSymbol)symbolTable.FindSymbol(node.Name, interfaceSymbol, SymbolFilter.Types);
+                        (TypeSymbol)symbolTable.FindSymbol(nodeName, interfaceSymbol, SymbolFilter.Types);
+
                     Debug.Assert(baseTypeSymbol.Type == SymbolType.Interface);
 
                     if (interfaces == null)

--- a/src/DSharp.Compiler/DSharpStringResources.cs
+++ b/src/DSharp.Compiler/DSharpStringResources.cs
@@ -10,6 +10,8 @@
         public static readonly string DSHARP_MEMBER_NAME_ATTRIBUTE = "DSharpScriptMemberName";
         public static readonly string SCRIPT_NAMESPACE_ATTRIBUTE = "ScriptNamespace";
         public static readonly string SCRIPT_IMPORT_ATTRIBUTE = "ScriptImport";
+        public static readonly string SCRIPT_IGNORE_ATTRIBUTE = "ScriptIgnore";
+        public static readonly string SCRIPT_IGNORE_ATTRIBUTE_FULLTYPENAME = "System.ScriptIgnore";
         public static readonly string SCRIPT_OBJECT_ATTRIBUTE = "ScriptObject";
         public static readonly string SCRIPT_EXTENSION_ATTRIBUTE = "ScriptExtension";
         public static readonly string SCRIPT_MODULE_ATTRIBUTE = "ScriptModule";

--- a/src/DSharp.Compiler/Importer/MetadataHelpers.cs
+++ b/src/DSharp.Compiler/Importer/MetadataHelpers.cs
@@ -134,6 +134,12 @@ namespace DSharp.Compiler.Importer
                 != null;
         }
 
+        public static bool IsIgnored(MethodDefinition method)
+        {
+            return GetAttribute(method, DSharpStringResources.SCRIPT_IGNORE_ATTRIBUTE_FULLTYPENAME)
+                != null;
+        }
+
         public static string GetScriptName(ICustomAttributeProvider attributeProvider, out bool preserveName,
                                            out bool preserveCase)
         {

--- a/src/DSharp.Compiler/Importer/MetadataImporter.cs
+++ b/src/DSharp.Compiler/Importer/MetadataImporter.cs
@@ -470,11 +470,18 @@ namespace DSharp.Compiler.Importer
                     continue;
                 }
 
+                // skip symbol generation for members decorated with [ScriptIgnore]
+                if (MetadataHelpers.IsIgnored(method))
+                {
+                    continue;
+                }
+
                 MethodSymbol methodSymbol = new MethodSymbol(
                     methodName, 
                     typeSymbol, 
                     returnType, 
                     MetadataHelpers.IsExtensionMethod(method));
+
                 methodSymbol.SetParseContext(method);
                 ImportMemberDetails(methodSymbol, method, method);
 

--- a/src/DSharp.Compiler/ScriptModel/Symbols/GenericParameterSymbol.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/GenericParameterSymbol.cs
@@ -1,11 +1,11 @@
-// GenericParameterSymbol.cs
+﻿// GenericParameterSymbol.cs
 // Script#/Core/Compiler
 // This source code is subject to terms and conditions of the Apache License, Version 2.0.
 //
 
 namespace DSharp.Compiler.ScriptModel.Symbols
 {
-    internal sealed class GenericParameterSymbol : TypeSymbol
+    internal sealed class GenericParameterSymbol : ClassSymbol
     {
         public GenericParameterSymbol(int index, string name, bool typeParameter, NamespaceSymbol parent)
             : base(SymbolType.GenericParameter, name, parent)

--- a/src/DSharp.Compiler/ScriptModel/Symbols/InterfaceSymbol.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/InterfaceSymbol.cs
@@ -8,15 +8,10 @@ using System.Diagnostics;
 
 namespace DSharp.Compiler.ScriptModel.Symbols
 {
-    internal class InterfaceSymbol : TypeSymbol
+    internal sealed class InterfaceSymbol : TypeSymbol
     {
         public InterfaceSymbol(string name, NamespaceSymbol parent)
             : base(SymbolType.Interface, name, parent)
-        {
-        }
-
-        protected InterfaceSymbol(SymbolType type, string name, NamespaceSymbol parent)
-            : base(type, name, parent)
         {
         }
 

--- a/src/DSharp.Compiler/ScriptModel/Symbols/InterfaceSymbol.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/InterfaceSymbol.cs
@@ -1,4 +1,4 @@
-// InterfaceSymbol.cs
+﻿// InterfaceSymbol.cs
 // Script#/Core/Compiler
 // This source code is subject to terms and conditions of the Apache License, Version 2.0.
 //
@@ -8,10 +8,15 @@ using System.Diagnostics;
 
 namespace DSharp.Compiler.ScriptModel.Symbols
 {
-    internal sealed class InterfaceSymbol : TypeSymbol
+    internal class InterfaceSymbol : TypeSymbol
     {
         public InterfaceSymbol(string name, NamespaceSymbol parent)
             : base(SymbolType.Interface, name, parent)
+        {
+        }
+
+        protected InterfaceSymbol(SymbolType type, string name, NamespaceSymbol parent)
+            : base(type, name, parent)
         {
         }
 

--- a/src/DSharp.Compiler/ScriptModel/Symbols/SymbolSet.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/SymbolSet.cs
@@ -981,6 +981,16 @@ namespace DSharp.Compiler.ScriptModel.Symbols
             {
                 Debug.Assert(context != null);
 
+                if (context is MethodSymbol methodContext)
+                {
+                    var genericType = methodContext.GenericArguments?.SingleOrDefault(a => a.Name == name);
+
+                    if (genericType != null)
+                    {
+                        return genericType;
+                    }
+                }
+
                 TypeSymbol typeSymbol = context as TypeSymbol;
 
                 if (typeSymbol == null)

--- a/src/DSharp.Compiler/Utility.cs
+++ b/src/DSharp.Compiler/Utility.cs
@@ -27,13 +27,12 @@ namespace DSharp.Compiler
             "if", "switch", "var", "catch", "else", "in", "this",
             "void", "continue", "false", "instanceof", "throw", "while",
             "debugger", "finally", "new", "true", "with", "default",
-            "for", "null", "try",
-            // Future reserved words
+            "for", "null", "try", "volatile",
             "abstract", "double", "goto", "native", "static", "boolean",
             "enum", "implements", "package", "super", "byte", "export",
             "import", "private", "synchronized", "char", "extends", "int",
-            "protected", "throws", "class", "final", "interface", "public",
-            "transient", "const", "float", "long", "short", "volatile",
+            "protected", "throws", "class", "sealed", "interface", "public",
+            "const", "float", "long", "short",
             // Script specific words
             DSharpStringResources.DSHARP_SCRIPT_NAME, "global"
         };

--- a/src/DSharp.Compiler/Validator/CustomTypeNodeValidator.cs
+++ b/src/DSharp.Compiler/Validator/CustomTypeNodeValidator.cs
@@ -164,8 +164,9 @@ namespace DSharp.Compiler.Validator
                     }
 
                     string name = memberNode.Name;
+                    AttributeNode ignoreAttribute = AttributeNode.FindAttribute(memberNode.Attributes, DSharpStringResources.SCRIPT_IGNORE_ATTRIBUTE);
 
-                    if (memberNames.ContainsKey(name))
+                    if (ignoreAttribute == null && memberNames.ContainsKey(name))
                     {
                         errorHandler.ReportNodeValidationError(DSharpStringResources.UNSUPPORTED_METHOD_OVERLOAD, memberNode);
                     }

--- a/src/DSharp.Mscorlib/Array.cs
+++ b/src/DSharp.Mscorlib/Array.cs
@@ -8,7 +8,7 @@ namespace System
     [ScriptIgnoreNamespace]
     [ScriptImport]
     [ScriptName("Array")]
-    public abstract partial class Array : IList, ICollection, IEnumerable
+    public sealed partial class Array : IList, ICollection, IEnumerable
     {
         [ScriptField]
         public extern object this[int index]

--- a/src/DSharp.Mscorlib/Collections/Generic/IEnumerable.cs
+++ b/src/DSharp.Mscorlib/Collections/Generic/IEnumerable.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {

--- a/src/DSharp.Mscorlib/Collections/Generic/IEnumerator.cs
+++ b/src/DSharp.Mscorlib/Collections/Generic/IEnumerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {

--- a/src/DSharp.Mscorlib/Collections/Generic/List.cs
+++ b/src/DSharp.Mscorlib/Collections/Generic/List.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections;
+using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
@@ -59,7 +60,7 @@ namespace System.Collections.Generic
 
         public extern void ForEach(Action<T> action);
 
-        [ScriptSkip]
+        [DSharpScriptMemberName("toArray")]
         public extern T[] ToArray();
 
         [ScriptSkip]

--- a/src/DSharp.Mscorlib/NonStandard/Array.cs
+++ b/src/DSharp.Mscorlib/NonStandard/Array.cs
@@ -4,8 +4,10 @@ using NonStandard;
 
 namespace System
 {
-    public abstract partial class Array
+    public partial class Array
     {
+        private Array() { }
+
         [ScriptName("push")]
         [Obsolete(ObsoleteConsts.MESSAGE_ON_OBSOLETE, ObsoleteConsts.ERROR_ON_OBSOLETE)]
         public extern void AddRange(params object[] items);


### PR DESCRIPTION
- [x] Parser
- [x] Passing `in` generics
- [x] Generic implementations (uses an anonymous symbol that inherits from the constraints for code generation)
- [ ] Validators for the caller (compiler error if constraints aren't matched)

Not supported:
- `typeof(T)` due to JavaScript runtime limitations (they have the same issue in TypeScript)