### PR TITLE
Fix IDictionary tests

### DIFF
--- a/src/DSharp.Compiler.Tests/Source/Expression/Dictionary/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Dictionary/Baseline.txt
@@ -7,28 +7,18 @@ define('test', ['ss'], function(ss) {
   function App() {
   }
   var App$ = {
-    getData: function() {
-      return null;
-    },
-    getData2: function() {
-      return null;
-    },
-    test: function(arg) {
-      var dictionary1 = {};
-    },
-    test2: function(arg) {
+    testDictionary: function(arg) {
       var dictionary1 = {};
       var key = 'blah';
       var c = ss.keys(dictionary1).length;
-      var c2 = ss.keys(this.getData()).length;
       delete dictionary1.aaa;
       delete dictionary1['Proxy-Connection'];
+      delete dictionary1['Proxy.Connection'];
       delete dictionary1[key];
       ss.clearKeys(dictionary1);
       dictionary1['asd'] = 3;
       var val = dictionary1['asd'];
       ss.addKeyValue(dictionary1, 'hello', 'bye');
-      ss.keyExists(dictionary1, 'asd');
       ss.keyExists(dictionary1, 'asd');
       for (var $key1 in dictionary1) {
         var pair = { key: $key1, value: dictionary1[$key1] };
@@ -38,23 +28,41 @@ define('test', ['ss'], function(ss) {
       var keys = ss.keys(dictionary1);
       var values = ss.values(dictionary1);
     },
-    test3: function(arg) {
+    testIDictionary_T: function(arg) {
       var dictionary1 = {};
       var key = 'blah';
       var c = ss.keys(dictionary1).length;
-      var c2 = ss.keys(this.getData2()).length;
-      var b = ss.keyExists(dictionary1, 'aaa');
       delete dictionary1.aaa;
+      delete dictionary1['Proxy-Connection'];
+      delete dictionary1['Proxy.Connection'];
+      delete dictionary1[key];
+      ss.clearKeys(dictionary1);
+      ss.setItem(dictionary1, 'asd', 3);
+      var val = ss.getItem(dictionary1, 'asd');
+      ss.addKeyValue(dictionary1, 'hello', 'bye');
+      ss.keyExists(dictionary1, 'asd');
+      for (var $key1 in dictionary1) {
+        var pair = { key: $key1, value: dictionary1[$key1] };
+        var myKey = pair.key;
+        var myValue = pair.value;
+      }
+      var keys = ss.keys(dictionary1);
+      var values = ss.values(dictionary1);
+    },
+    testIDictionary: function(arg) {
+      var dictionary1 = {};
+      var key = 'blah';
+      var c = ss.keys(dictionary1).length;
+      delete dictionary1.aaa;
+      delete dictionary1['Proxy.Connection'];
       delete dictionary1['Proxy-Connection'];
       delete dictionary1[key];
       ss.clearKeys(dictionary1);
+      ss.setItem(dictionary1, 'asd', 3);
+      var val = ss.getItem(dictionary1, 'asd');
+      ss.addKeyValue(dictionary1, 'hello', 'bye');
       var keys = ss.keys(dictionary1);
-    },
-    test4: function(arg) {
-      var d1 = {};
-      d1[1] = d1[arg] = 'aaa';
-      delete d1[1];
-      delete d1[arg];
+      var values = ss.values(dictionary1);
     }
   };
 

--- a/src/DSharp.Compiler.Tests/Source/Expression/Dictionary/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Dictionary/Code.cs
@@ -9,27 +9,14 @@ namespace ExpressionTests {
 
     public class App {
 
-        public IDictionary GetData() {
-            return null;
-        }
-
-        public IDictionary<string, int> GetData2() {
-            return null;
-        }
-
-        public void Test(int arg) {
-            Dictionary<string, object> dictionary1 = new Dictionary<string, object>();
-        }
-
-        public void Test2(int arg) {
+        public void TestDictionary(int arg) {
             Dictionary<string, object> dictionary1 = new Dictionary<string, object>();
             string key = "blah";
             int c = dictionary1.Keys.Count;
 
-            int c2 = GetData().Keys.Count;
-
             dictionary1.Remove("aaa");
             dictionary1.Remove("Proxy-Connection");
+            dictionary1.Remove("Proxy.Connection");
             dictionary1.Remove(key);
 
             dictionary1.Clear();
@@ -40,7 +27,6 @@ namespace ExpressionTests {
             dictionary1.Add("hello", "bye");
 
             dictionary1.ContainsKey("asd");
-            dictionary1.Contains("asd");
 
             foreach (KeyValuePair<string, object> pair in dictionary1)
             {
@@ -52,29 +38,54 @@ namespace ExpressionTests {
             ICollection<object> values = dictionary1.Values;
         }
 
-        public void Test3(int arg) {
-            Dictionary<string, int> dictionary1 = new Dictionary<string, int>();
+        public void TestIDictionary_T(int arg) {
+            IDictionary<string, object> dictionary1 = new Dictionary<string, object>();
             string key = "blah";
             int c = dictionary1.Keys.Count;
 
-            int c2 = GetData2().Keys.Count;
+            dictionary1.Remove("aaa");
+            dictionary1.Remove("Proxy-Connection");
+            dictionary1.Remove("Proxy.Connection");
+            dictionary1.Remove(key);
 
-            bool b = dictionary1.ContainsKey("aaa");
+            dictionary1.Clear();
+
+            dictionary1["asd"] = 3;
+            object val = dictionary1["asd"];
+
+            dictionary1.Add("hello", "bye");
+
+            dictionary1.ContainsKey("asd");
+
+            foreach (KeyValuePair<string, object> pair in dictionary1)
+            {
+                string myKey = pair.Key;
+                object myValue = pair.Value;
+            }
+
+            ICollection<string> keys = dictionary1.Keys;
+            ICollection<object> values = dictionary1.Values;
+        }
+
+        public void TestIDictionary(int arg) {
+            IDictionary dictionary1 = new Dictionary<string, object>();
+            string key = "blah";
+            int c = dictionary1.Keys.Count;
 
             dictionary1.Remove("aaa");
+            dictionary1.Remove("Proxy.Connection");
             dictionary1.Remove("Proxy-Connection");
             dictionary1.Remove(key);
 
             dictionary1.Clear();
-            
-            string[] keys = dictionary1.Keys;
-        }
 
-        public void Test4(int arg) {
-            Dictionary<int, string> d1 = new Dictionary<int, string>();
-            d1[1] = d1[arg] = "aaa";
-            d1.Remove(1);
-            d1.Remove(arg);
+            dictionary1["asd"] = 3;
+            object val = dictionary1["asd"];
+
+            dictionary1.Add("hello", "bye");
+
+            ICollection keys = dictionary1.Keys;
+            ICollection values = dictionary1.Values;
         }
     }
 }

--- a/src/DSharp.Mscorlib/Collections/Generic/IDictionary.cs
+++ b/src/DSharp.Mscorlib/Collections/Generic/IDictionary.cs
@@ -18,11 +18,14 @@ namespace System.Collections.Generic
 
         ICollection<TValue> Values { get; }
 
-        [DSharpScriptMemberName("keyExists")]
-        bool ContainsKey(TKey key);
-
         [DSharpScriptMemberName("addKeyValue")]
         void Add(TKey key, TValue value);
+
+        [DSharpScriptMemberName("clearKeys")]
+        void Clear();
+
+        [DSharpScriptMemberName("keyExists")]
+        bool ContainsKey(TKey key);
 
         bool Remove(TKey key);
     }

--- a/src/DSharp.Mscorlib/Collections/IDictionary.cs
+++ b/src/DSharp.Mscorlib/Collections/IDictionary.cs
@@ -19,6 +19,7 @@ namespace System.Collections
         [DSharpScriptMemberName("keyExists")]
         bool Contains(object key);
 
+        [DSharpScriptMemberName("addKeyValue")]
         void Add(object key, object value);
 
         [DSharpScriptMemberName("clearKeys")]

--- a/src/DSharp.Mscorlib/Runtime/CompilerServices/ScriptIgnoreAttribute.cs
+++ b/src/DSharp.Mscorlib/Runtime/CompilerServices/ScriptIgnoreAttribute.cs
@@ -3,8 +3,7 @@
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
-    /// This attribute can be placed on types in system script assemblies that should not
-    /// be imported. It is only meant to be used within mscorlib.dll.
+    /// This attribute can be placed on types/methods in system script assemblies that should not be imported/transpiled.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Delegate | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
     [ScriptIgnore]

--- a/src/DSharp.Script/src/System/Collections/CollectionHelpers.js
+++ b/src/DSharp.Script/src/System/Collections/CollectionHelpers.js
@@ -44,6 +44,11 @@ function keyExists(obj, key) {
 function keyValueExists(obj, keyValue) {
     return obj[keyValue.key] === keyValue.value;
 }
+
+function addKeyValue(obj, key, value) {
+    return obj[key] = value;
+}
+
 function keys(obj) {
     if (Object.keys) {
         return Object.keys(obj);


### PR DESCRIPTION
The current implementation doesn't allow implementing a custom `IDictionary`, but we are close.
This PR covers the already implemented functionality, in order to avoid breaking it.