### PR TITLE
Task/extension fixes

### DIFF
--- a/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
@@ -684,7 +684,7 @@ namespace DSharp.Compiler.Compiler
 
             if (objectExpression == null)
             {
-                throw new ExpressionBuildException($"ObjectExpression is null: {{{node.LeftChild.Token.Location}}} - {{{node.RightChild.Token.Location}}}");
+                return null;
             }
 
             if (objectExpression is LiteralExpression)
@@ -816,7 +816,10 @@ namespace DSharp.Compiler.Compiler
                 }
             }
 
-            Debug.Assert(objectExpression != null);
+            if(objectExpression == null)
+            {
+                Debugger.Launch();
+            }
 
             if (objectExpression == null)
             {
@@ -1005,7 +1008,7 @@ namespace DSharp.Compiler.Compiler
         private TypeSymbol ResolveTypeNode(BinaryExpressionNode node)
         {
             MethodDeclarationNode parentMethod = FindParentNode<MethodDeclarationNode>(node);
-            var token = parentMethod.Parameters.FirstOrDefault()?.Token;
+            var token = parentMethod?.Parameters?.FirstOrDefault()?.Token;
             var typeNode = symbolSet.ResolveIntrinsicToken(token);
             return typeNode;
         }
@@ -1105,11 +1108,10 @@ namespace DSharp.Compiler.Compiler
         private Expression ProcessNameNode(NameNode node, SymbolFilter filter)
         {
             Symbol symbol = ResolveNameNodeSymbol(node, filter);
-            //Debug.Assert(symbol != null);
 
             if (symbol == null)
             {
-                throw new ExpressionBuildException($"Null Symbol for node: {node.Token.Location}");
+                return null;
             }
 
             if (symbol is LocalSymbol localSymbol)

--- a/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
+++ b/src/DSharp.Compiler/Compiler/ExpressionBuilder.cs
@@ -793,9 +793,19 @@ namespace DSharp.Compiler.Compiler
                 }
                 else if (node.LeftChild.Token is IdentifierToken identifier)
                 {
-                    MethodDeclarationNode parentMethod = FindParentNode<MethodDeclarationNode>(node);
-                    var token = parentMethod.Parameters.First().Token;
-                    var typeNode = symbolSet.ResolveIntrinsicToken(token);
+                    TypeSymbol typeNode = ResolveTypeNode(node);
+
+                    if(typeNode == null)
+                    {
+                        var symbol = symbolTable.FindSymbol(
+                            identifier.Identifier,
+                            memberContext, SymbolFilter.AnyMember | SymbolFilter.Members | SymbolFilter.Locals);
+
+                        if (symbol is LocalSymbol localSymbol)
+                            typeNode = localSymbol.ValueType;
+                        else if (symbol is MemberSymbol member)
+                            typeNode = member.AssociatedType;
+                    }
 
                     Expression extensionMethodInvocation = CreateExtensionMethodInvocationExpression(node, typeNode);
 
@@ -990,6 +1000,14 @@ namespace DSharp.Compiler.Compiler
             }
 
             return expression;
+        }
+
+        private TypeSymbol ResolveTypeNode(BinaryExpressionNode node)
+        {
+            MethodDeclarationNode parentMethod = FindParentNode<MethodDeclarationNode>(node);
+            var token = parentMethod.Parameters.FirstOrDefault()?.Token;
+            var typeNode = symbolSet.ResolveIntrinsicToken(token);
+            return typeNode;
         }
 
         private Expression CreateExtensionMethodInvocationExpression(BinaryExpressionNode node, TypeSymbol typeToExtend)

--- a/src/DSharp.Compiler/Generator/ExpressionGenerator.cs
+++ b/src/DSharp.Compiler/Generator/ExpressionGenerator.cs
@@ -414,7 +414,8 @@ namespace DSharp.Compiler.Generator
 
                     break;
                 case ExpressionType.Member:
-                    throw new ScriptGeneratorException(symbol, "MemberExpression missed from conversion to higher level expression.");
+                    GenerateMemberExpression(generator, symbol, (MemberExpression)expression);
+                    break;
                 case ExpressionType.Field:
                     GenerateFieldExpression(generator, symbol, (FieldExpression)expression);
 
@@ -501,6 +502,18 @@ namespace DSharp.Compiler.Generator
             {
                 writer.Write(")");
             }
+        }
+
+        private static void GenerateMemberExpression(ScriptGenerator generator, MemberSymbol symbol, MemberExpression expression)
+        {
+            ScriptTextWriter writer = generator.Writer;
+
+            if (expression.RequiresThisContext)
+            {
+                writer.Write("this.");
+            }
+
+            writer.Write(expression.Member.GeneratedName);
         }
 
         private static void GenerateObjectExpression(ScriptGenerator generator, MemberSymbol symbol, ObjectExpression expression)

--- a/src/DSharp.Compiler/ScriptModel/Symbols/SymbolSet.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/SymbolSet.cs
@@ -726,6 +726,11 @@ namespace DSharp.Compiler.ScriptModel.Symbols
 
         public TypeSymbol ResolveIntrinsicToken(Token token)
         {
+            if(token == null)
+            {
+                return null;
+            }
+
             IntrinsicType intrinsicType = IntrinsicType.Void;
 
             switch (token.Type)

--- a/src/DSharp.Compiler/ScriptModel/Symbols/TypeSymbol.cs
+++ b/src/DSharp.Compiler/ScriptModel/Symbols/TypeSymbol.cs
@@ -310,10 +310,16 @@ namespace DSharp.Compiler.ScriptModel.Symbols
                 }
             }
 
-            if (symbol == null && parentSymbolTable != null &&
-                (filter & SymbolFilter.ExcludeParent) == 0)
+            if(symbol == null && !filter.HasFlag(SymbolFilter.ExcludeParent))
             {
-                symbol = parentSymbolTable.FindSymbol(name, context, filter);
+                if (parentSymbolTable != null)
+                {
+                    symbol = parentSymbolTable.FindSymbol(name, context, filter);
+                }
+                else if (context?.Parent is ISymbolTable symbolTable)
+                {
+                    symbolTable.FindSymbol(name, context, filter);
+                }
             }
 
             return symbol;


### PR DESCRIPTION
- Fixing an issue where we wouldn't query a parent symbol correctly
- Resolved an incorrect implementation of how to resolve extension methods outside of a static context. 
