### PR TITLE
Fixing issues with generics and generic extensions

### DIFF
--- a/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Baseline.txt
@@ -2,6 +2,16 @@
 
 define('ExpressionTests.ExtensionMethods', ['ss'], function(ss) {
   var $global = this;
+  // ExpressionTests.IServiceCollection
+
+  function IServiceCollection() { }
+
+
+  // ExpressionTests.ITemp
+
+  function ITemp() { }
+
+
   // ExpressionTests.StringExtensions
 
   function StringExtensions() {
@@ -29,12 +39,27 @@ define('ExpressionTests.ExtensionMethods', ['ss'], function(ss) {
   };
 
 
+  // ExpressionTests.IServiceCollectionExtension
+
+  function IServiceCollectionExtension() {
+  }
+  IServiceCollectionExtension.addSingleton = function($TArgs, services, value) {
+  };
+  IServiceCollectionExtension.addSingletonMany = function($TArgs, services, value) {
+  };
+
+
   // ExpressionTests.Program
 
   function Program() {
   }
   Program.main = function(args) {
     var value = StringExtensions.padRightC(StringExtensions.padRightC(StringExtensions.padRightC('', 10, 'F'), 10, 'F'), 10, 'F');
+    var services = null;
+    IServiceCollectionExtension.addSingleton({T: Temp}, services, 1);
+    IServiceCollectionExtension.addSingletonMany({TBase: ITemp, TImp: Temp}, services, 1);
+    services.addSpecialSingleton({T: Temp});
+    services.addSpecialSingleton2({T: Temp}, 1);
     return IntExtensions.increment(0);
   };
   var Program$ = {
@@ -42,14 +67,27 @@ define('ExpressionTests.ExtensionMethods', ['ss'], function(ss) {
   };
 
 
+  // ExpressionTests.Temp
+
+  function Temp() {
+  }
+  var Temp$ = {
+
+  };
+
+
   var $exports = ss.module('ExpressionTests.ExtensionMethods',
     {
-      InternalIntExtensions: ss.defineClass(InternalIntExtensions, null, [], null)
+      InternalIntExtensions: ss.defineClass(InternalIntExtensions, null, [], null),
+      IServiceCollectionExtension: ss.defineClass(IServiceCollectionExtension, null, [], null)
     },
     {
+      IServiceCollection: ss.defineInterface(IServiceCollection),
+      ITemp: ss.defineInterface(ITemp),
       StringExtensions: ss.defineClass(StringExtensions, null, [], null),
       IntExtensions: ss.defineClass(IntExtensions, null, [], null),
-      Program: ss.defineClass(Program, Program$, [], null)
+      Program: ss.defineClass(Program, Program$, [], null),
+      Temp: ss.defineClass(Temp, Temp$, [], null, [ITemp])
     });
 
 

--- a/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Baseline.txt
@@ -43,7 +43,7 @@ define('ExpressionTests.ExtensionMethods', ['ss'], function(ss) {
 
   function IServiceCollectionExtension() {
   }
-  IServiceCollectionExtension.addSingleton = function($TArgs, services, value) {
+  IServiceCollectionExtension.addSingleton = function($TArgs, services) {
   };
   IServiceCollectionExtension.addSingletonMany = function($TArgs, services, value) {
   };
@@ -56,7 +56,7 @@ define('ExpressionTests.ExtensionMethods', ['ss'], function(ss) {
   Program.main = function(args) {
     var value = StringExtensions.padRightC(StringExtensions.padRightC(StringExtensions.padRightC('', 10, 'F'), 10, 'F'), 10, 'F');
     var services = null;
-    IServiceCollectionExtension.addSingleton({T: Temp}, services, 1);
+    IServiceCollectionExtension.addSingleton({T: Temp}, services);
     IServiceCollectionExtension.addSingletonMany({TBase: ITemp, TImp: Temp}, services, 1);
     services.addSpecialSingleton({T: Temp});
     services.addSpecialSingleton2({T: Temp}, 1);

--- a/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Code.cs
@@ -29,6 +29,26 @@ namespace ExpressionTests
         }
     }
 
+    internal static class IServiceCollectionExtension
+    {
+        public static IServiceCollection AddSingleton<T>(this IServiceCollection services, int value)
+        {
+
+        }
+
+        public static IServiceCollection AddSingletonMany<TBase, TImp>(this IServiceCollection services, int value)
+        {
+
+        }
+    }
+
+    public interface IServiceCollection
+    {
+        IServiceCollection AddSpecialSingleton<T>();
+
+        IServiceCollection AddSpecialSingleton2<T>(int value);
+    }
+
     public class Program
     {
         public static int Main(string[] args)
@@ -37,7 +57,21 @@ namespace ExpressionTests
                 .PadRightC(10, 'F')
                 .PadRightC(10, 'F');
 
+            IServiceCollection services = null;
+            services.AddSingleton<Temp>(1);
+            services.AddSingletonMany<ITemp, Temp>(1);
+            services.AddSpecialSingleton<Temp>();
+            services.AddSpecialSingleton2<Temp>(1);
+
             return 0.Increment();
         }
+    }
+
+    public class Temp : ITemp
+    {
+    }
+
+    public interface ITemp
+    {
     }
 }

--- a/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/ExtensionMethods/Code.cs
@@ -31,7 +31,7 @@ namespace ExpressionTests
 
     internal static class IServiceCollectionExtension
     {
-        public static IServiceCollection AddSingleton<T>(this IServiceCollection services, int value)
+        public static IServiceCollection AddSingleton<T>(this IServiceCollection services)
         {
 
         }
@@ -58,7 +58,7 @@ namespace ExpressionTests
                 .PadRightC(10, 'F');
 
             IServiceCollection services = null;
-            services.AddSingleton<Temp>(1);
+            services.AddSingleton<Temp>();
             services.AddSingletonMany<ITemp, Temp>(1);
             services.AddSpecialSingleton<Temp>();
             services.AddSpecialSingleton2<Temp>(1);

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics4/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics4/Baseline.txt
@@ -26,7 +26,7 @@ define('test', ['ss'], function(ss) {
       var outInt = instance.Value.Value;
       this.parseTheList({T: Number}, []).push(4);
       var wrapper = new Wrapper();
-      var newWrapper = wrapper.Invokee.invoke({T: Wrapper}, '');
+      wrapper.Invokee.invoke({T: ss.getGenericConstructor(GenericClass_$1, {T: Number})}, '').doSomethingWith({TNew: Boolean}, true, 0);
     },
     parseTheList: function($TArgs, what) {
       return what;

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics4/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics4/Baseline.txt
@@ -25,6 +25,8 @@ define('test', ['ss'], function(ss) {
       var instance = ss.createGenericType(GenericClass_$1, {T : ss.getGenericConstructor(GenericClass_$1, {T : Number})}, ss.createGenericType(GenericClass_$1, {T : Number}, 1));
       var outInt = instance.Value.Value;
       this.parseTheList({T: Number}, []).push(4);
+      var wrapper = new Wrapper();
+      var newWrapper = wrapper.Invokee.invoke({T: Wrapper}, '');
     },
     parseTheList: function($TArgs, what) {
       return what;
@@ -67,6 +69,26 @@ define('test', ['ss'], function(ss) {
   };
 
 
+  // TypeTests.Wrapper
+
+  function Wrapper() {
+  }
+  var Wrapper$ = {
+
+  };
+
+
+  // TypeTests.Invoker
+
+  function Invoker() {
+  }
+  var Invoker$ = {
+    invoke: function($TArgs, value) {
+      return null;
+    }
+  };
+
+
   var $exports = ss.module('test',
     {
       Usages: ss.defineClass(Usages, Usages$, [], null)
@@ -74,7 +96,9 @@ define('test', ['ss'], function(ss) {
     {
       Usages$IBase: ss.defineInterface(Usages$IBase),
       Usages$ImplementsBase: ss.defineClass(Usages$ImplementsBase, Usages$ImplementsBase$, [], null, [Usages$IBase]),
-      GenericClass_$1: ss.defineClass(GenericClass_$1, GenericClass_$1$, [Object], null)
+      GenericClass_$1: ss.defineClass(GenericClass_$1, GenericClass_$1$, [Object], null),
+      Wrapper: ss.defineClass(Wrapper, Wrapper$, [], null),
+      Invoker: ss.defineClass(Invoker, Invoker$, [], null)
     });
 
 

--- a/src/DSharp.Compiler.Tests/Source/Expression/Generics4/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Expression/Generics4/Code.cs
@@ -21,6 +21,9 @@ namespace TypeTests
             var outInt = instance.Value.Value;
 
             ParseTheList<int>(new List<int>() { 1, 2, 3 }).Add(4);
+
+            Wrapper wrapper = new Wrapper();
+            wrapper.Invokee.Invoke<GenericClass<int>>("").DoSomethingWith<bool>(true, 0);
         }
 
         public interface IBase { }
@@ -73,6 +76,20 @@ namespace TypeTests
         {
             Type baseT = typeof(TBase);
             Type implT = typeof(TImplementation);
+        }
+    }
+
+    public class Wrapper
+    {
+        public Invoker Invokee { get; }
+    }
+
+    public class Invoker
+    {
+        public T Invoke<T>(string value)
+            where T : class
+        {
+            return null;
         }
     }
 }


### PR DESCRIPTION
- Fixed an issue where generic extensions wouldn't emit type maps
- Fixed an issue with generic invocations on complex binary expression chains
- Fixed an issue with type inference for methods only being one level deep.