### PR TITLE
Avoid createGenericType for Imported Types with Generics

### DIFF
--- a/src/DSharp.Compiler.Tests/Source/Type/GenericClasses/baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Type/GenericClasses/baseline.txt
@@ -23,7 +23,7 @@ define('test', ['ss'], function(ss) {
     var copiedValues = Program.copyDictionary(values);
     var copiedValues2 = Program.copyDictionary(values2);
     var copiedValuesOfStrings = Program.copyDictionary(Program.copyDictionaryOfStringKeys(values));
-    var bem = ss.createGenericType(BulkAsyncExecutionManager_$1, {T : String}, );
+    var bem = ss.createGenericType(BulkAsyncExecutionManager_$1, {T : String});
     bem.addExecutionKey('');
     bem.addExecutionKeys([ 'Lol', 'asdasd', 'hashasd' ]);
     bem.startExecution();
@@ -33,7 +33,7 @@ define('test', ['ss'], function(ss) {
     }
     if (ss.canAssign(ss.getGenericConstructor(IBulkAsyncExecutionManager_$1, {T: String}), ss.typeOf(bem))) {
     }
-    var genericWithMultipleParams = ss.createGenericType(GenericWithMultipleParams_$3, {T1 : Number, T2 : Boolean, T3 : String}, );
+    var genericWithMultipleParams = ss.createGenericType(GenericWithMultipleParams_$3, {T1 : Number, T2 : Boolean, T3 : String});
     var str = genericWithMultipleParams.toString();
     var specificClassOfGeneric = new SpecificClassOfGeneric();
     var isInt = specificClassOfGeneric.Type === Number;

--- a/src/DSharp.Compiler/Generator/ExpressionGenerator.cs
+++ b/src/DSharp.Compiler/Generator/ExpressionGenerator.cs
@@ -1155,10 +1155,13 @@ namespace DSharp.Compiler.Generator
                 }
             }
 
-            if(expression.AssociatedType.IsGeneric && (expression.AssociatedType.GenericArguments?.Any() ?? false))
+            if (expression.AssociatedType.IsGeneric
+                && expression.AssociatedType.GenericType.IsApplicationType
+                && (expression.AssociatedType.GenericArguments?.Any() ?? false))
             {
                 writer.Write(DSharpStringResources.ScriptExportMember("createGenericType"));
                 writer.Write("(");
+
                 if (expression.IsSpecificType)
                 {
                     writer.Write(expression.AssociatedType.FullGeneratedName);
@@ -1167,13 +1170,16 @@ namespace DSharp.Compiler.Generator
                 {
                     GenerateExpression(generator, symbol, expression.TypeExpression);
                 }
+
                 writer.Write(", ");
                 generator.WriteGenericTypeArgumentsMap(expression.AssociatedType.GenericArguments, expression.AssociatedType.GenericParameters);
-                writer.Write(", ");
+                
                 if (expression.Parameters != null)
                 {
+                    writer.Write(", ");
                     GenerateExpressionList(generator, symbol, expression.Parameters);
                 }
+
                 writer.Write(")");
             }
             else


### PR DESCRIPTION
When a type is imported, this is just a C# api for a Native JS type. These C# types can benefit from generics and strong typing, but shouldn't generate any code for dealing with types.

It also fixes a bug where there was a syntax error when there are no type arguments (it should error in the analyzer, not here)