### PR TITLE
Make DSHarp SDKs Id and references lower case

### DIFF
--- a/src/DSharp.Sdk/DSharp.Sdk.csproj
+++ b/src/DSharp.Sdk/DSharp.Sdk.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     
-    <PackageId>DSharp.Sdk</PackageId>
+    <PackageId>dsharp.sdk</PackageId>
     <Title>DSharp Sdk</Title>
     <Description>Defines the MSBuild Compliant DSharp project sdk</Description>
     <PackageType>MSBuildSdk</PackageType>

--- a/src/DSharp.Sdk/DSharp.Sdk.nuspec
+++ b/src/DSharp.Sdk/DSharp.Sdk.nuspec
@@ -1,6 +1,6 @@
 ﻿<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>DSharp.Sdk</id>
+    <id>dsharp.sdk</id>
     <title>DSharp Sdk</title>
     <authors>$authors$</authors>
     <version>$version$</version>

--- a/src/DSharp.Sdk/readme.md
+++ b/src/DSharp.Sdk/readme.md
@@ -18,7 +18,7 @@ To create a new DSharp project is now as simple as updating the Sdk attribute in
 
 ```xml
 
-<Project Sdk="DSharp.Sdk" Version="1.2.3">
+<Project Sdk="dsharp.sdk" Version="1.2.3">
   <PropertyGroup>
     <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
@@ -36,7 +36,7 @@ Sdk versions can be specified globally using a global.json file. If you are usin
 
 {
   "msbuild-sdks": {
-    "DSharp.Sdk": "1.2.3",
+    "dsharp.sdk": "1.2.3",
   }
 }
 

--- a/src/DSharp.Web.Sdk/DSharp.Web.Sdk.csproj
+++ b/src/DSharp.Web.Sdk/DSharp.Web.Sdk.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-    <PackageId>DSharp.Web.Sdk</PackageId>
+    <PackageId>dsharp.web.sdk</PackageId>
     <Title>DSharp Web Sdk</Title>
     <Description>Defines the MSBuild Compliant DSharp project sdk, with additional browser api imports</Description>
     <PackageType>MSBuildSdk</PackageType>

--- a/src/DSharp.Web.Sdk/DSharp.Web.Sdk.nuspec
+++ b/src/DSharp.Web.Sdk/DSharp.Web.Sdk.nuspec
@@ -1,6 +1,6 @@
 ﻿<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
-    <id>DSharp.Web.Sdk</id>
+    <id>dsharp.web.sdk</id>
     <title>DSharp Web Sdk</title>
     <authors>$authors$</authors>
     <version>$version$</version>

--- a/src/DSharp.Web.Sdk/Sdk/Sdk.props
+++ b/src/DSharp.Web.Sdk/Sdk/Sdk.props
@@ -3,6 +3,6 @@
     <ImportedSdks>DSharp.Web.Sdk.props;$(ImportedSdks)</ImportedSdks>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="DSharp.Sdk" Condition="$(ImportedSdks.Contains('DSharp.Sdk.props')) == false"/>
+  <Import Project="Sdk.props" Sdk="dsharp.sdk" Condition="$(ImportedSdks.Contains('DSharp.Sdk.props')) == false"/>
   <Import Condition="$(IsDSharpBuild)" Project="$(MSBuildThisFileDirectory)DSharp.props"/>
 </Project>

--- a/src/DSharp.Web.Sdk/Sdk/Sdk.targets
+++ b/src/DSharp.Web.Sdk/Sdk/Sdk.targets
@@ -3,5 +3,5 @@
     <ImportedSdks>DSharp.Web.Sdk.targets;$(ImportedSdks)</ImportedSdks>
   </PropertyGroup>
 
-  <Import Project="Sdk.targets" Sdk="DSharp.Sdk" Condition="$(ImportedSdks.Contains('DSharp.Sdk.targets')) == false"/>
+  <Import Project="Sdk.targets" Sdk="dsharp.sdk" Condition="$(ImportedSdks.Contains('DSharp.Sdk.targets')) == false"/>
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "DSharp.Sdk": "1.0.0"
+    "dsharp.sdk": "1.0.0"
   }
 }


### PR DESCRIPTION
This is a workaround because of an issue in Nuget causing intermittent build rerros in CI pipelines
https://github.com/NuGet/Home/issues/7817