### PR TITLE
Fix case where 2 aliases refer to the same type

### DIFF
--- a/src/DSharp.Compiler/Preprocessing/Lowering/VarRewriter.cs
+++ b/src/DSharp.Compiler/Preprocessing/Lowering/VarRewriter.cs
@@ -36,6 +36,8 @@ namespace DSharp.Compiler.Preprocessing.Lowering
             requiredUsings = new HashSet<string>();
             aliases = root.Usings
                 .Where(u => u.Alias is NameEqualsSyntax)
+                .GroupBy(u => u.Name.ToString())
+                .Select(g => g.First())
                 .ToDictionary(
                     keySelector: a => a.Name.ToString(),
                     elementSelector: a => a.Alias.ToString()


### PR DESCRIPTION
Example:
```cs
using X = MyLib.MyType;
using Y = MyLib.MyType;
```