### PR TITLE
fix metadata generation edge cases

### DIFF
--- a/src/DSharp.Compiler.Tests/Source/Type/Reflection/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Type/Reflection/Baseline.txt
@@ -2,21 +2,37 @@
 
 define('test', ['ss'], function(ss) {
   var $global = this;
+  // TypeTests.ExtendedInterface
+
+  function ExtendedInterface() { }
+
+
+  // TypeTests.BaseClass
+
+  function BaseClass() {
+  }
+  var BaseClass$ = {
+    dispose: function() {
+    }
+  };
+
+
   // TypeTests.MyClass
 
   function MyClass() {
     ss.defineProperty(this, 'Other', null);
     ss.defineProperty(this, 'Getter', 0);
     ss.defineProperty(this, 'Tyyype', null);
+    BaseClass.call(this);
     var members = ss.getMembers((MyClass));
-    MyClass._assert(members[0].Name === 'get_Item');
-    MyClass._assert(members[1].Name === 'set_Item');
-    MyClass._assert(members[2].Name === 'Getter');
-    MyClass._assert((members[2]).Type === Number);
-    MyClass._assert(members[3].Name === 'Method');
-    MyClass._assert((members[3]).Type == null);
+    MyClass._assert$1(members[0].Name === 'get_Item');
+    MyClass._assert$1(members[1].Name === 'set_Item');
+    MyClass._assert$1(members[2].Name === 'Getter');
+    MyClass._assert$1((members[2]).Type === Number);
+    MyClass._assert$1(members[3].Name === 'Method');
+    MyClass._assert$1((members[3]).Type == null);
   }
-  MyClass._assert = function(assertion) {
+  MyClass._assert$1 = function(assertion) {
   };
   var MyClass$ = {
     getDelegate: function() {
@@ -46,6 +62,7 @@ define('test', ['ss'], function(ss) {
 
   function MyClass_$1() {
     ss.defineProperty(this, 'Other', null);
+    BaseClass.call(this);
   }
   var MyClass_$1$ = {
 
@@ -54,8 +71,10 @@ define('test', ['ss'], function(ss) {
 
   var $exports = ss.module('test', null,
     {
-      MyClass: ss.defineClass(MyClass, MyClass$, [], null),
-      MyClass_$1: ss.defineClass(MyClass_$1, MyClass_$1$, [], null)
+      ExtendedInterface: ss.defineInterface(ExtendedInterface, [ss.IDisposable, ss.ICollection_$1]),
+      BaseClass: ss.defineClass(BaseClass, BaseClass$, [], null, [ss.IDisposable]),
+      MyClass: ss.defineClass(MyClass, MyClass$, [], BaseClass),
+      MyClass_$1: ss.defineClass(MyClass_$1, MyClass_$1$, [], BaseClass)
     });
 
 

--- a/src/DSharp.Compiler.Tests/Source/Type/Reflection/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Type/Reflection/Code.cs
@@ -10,7 +10,17 @@ namespace TypeTests {
 
     public delegate void Wooow();
 
-    public class MyClass
+    public class BaseClass : IDisposable
+    {
+        public virtual void Dispose() { }
+    }
+
+    public interface ExtendedInterface : IDisposable, ICollection<int>
+    {
+        IEnumerable Wow();
+    }
+
+    public class MyClass : BaseClass
     {
         public Wooow GetDelegate() { throw new Exception(); }
 
@@ -52,7 +62,7 @@ namespace TypeTests {
         }
     }
 
-    public class MyClass<T>
+    public class MyClass<T> : BaseClass
     {
         public MyClass Other { get; set; }
     }

--- a/src/DSharp.Compiler.Tests/Source/Type/Reflection/Metadata.txt
+++ b/src/DSharp.Compiler.Tests/Source/Type/Reflection/Metadata.txt
@@ -3,6 +3,13 @@ ss.registerMetadataImporter(function(){(function(ss) {
   var Void = null;
   var Type = Function;
   var module = ss.modules['test'];
+  module.ExtendedInterface.$members = [
+    {MemberType: 8,Name: 'wow', Type: eval("try{ss.IEnumerable}catch{}")},
+    {MemberType: 8,Name: 'dispose', Type: eval("try{Void}catch{}")},
+    {MemberType: 4,Name: 'length', Type: eval("try{Number}catch{}")},
+    {MemberType: 8,Name: 'push', Type: eval("try{Void}catch{}")}];
+  module.BaseClass.$members = [
+    {MemberType: 8,Name: 'dispose', Type: eval("try{Void}catch{}")}];
   module.MyClass.$members = [
     {MemberType: 8,Name: 'getDelegate', Type: eval("try{Function}catch{}")},
     {MemberType: 16,Name: 'Other', Type: eval("try{module.MyClass_$1}catch{}")},
@@ -12,7 +19,7 @@ ss.registerMetadataImporter(function(){(function(ss) {
     {MemberType: 8,Name: 'method2', Type: eval("try{Object}catch{}")},
     {MemberType: 8,Name: 'method3', Type: eval("try{ss.IEnumerable}catch{}")},
     {MemberType: 8,Name: 'method4', Type: eval("try{ss.IList_$1}catch{}")},
-    {MemberType: 8,Name: '_assert', Type: eval("try{Void}catch{}")},
+    {MemberType: 8,Name: '_assert$1', Type: eval("try{Void}catch{}")},
     {MemberType: 8,Name: 'get_item', Type: eval("try{Object}catch{}")},
     {MemberType: 8,Name: 'set_item', Type: eval("try{Object}catch{}")}];
   module.MyClass_$1.$members = [

--- a/src/DSharp.Compiler/Extensions/TypeSymbolExtensions.cs
+++ b/src/DSharp.Compiler/Extensions/TypeSymbolExtensions.cs
@@ -18,7 +18,7 @@ namespace DSharp.Compiler.Extensions
 
             if (symbol is InterfaceSymbol interfaceSymbol)
             {
-                var interfaces = new List<InterfaceSymbol> { interfaceSymbol };
+                var interfaces = new List<InterfaceSymbol>();
 
                 if (interfaceSymbol.Interfaces != null)
                 {
@@ -28,16 +28,16 @@ namespace DSharp.Compiler.Extensions
                 return interfaces;
             }
 
-            return null;
+            return Array.Empty<InterfaceSymbol>();
         }
 
         internal static bool ImplementsListType(this TypeSymbol symbol)
         {
             var interfaces = symbol.GetInterfaces();
 
-            if (interfaces == null)
+            if (symbol is InterfaceSymbol interfaceSymbol)
             {
-                return false;
+                interfaces.Add(interfaceSymbol);
             }
 
             return interfaces.Any(i => IsSpecifiedType(i, "System.Collections", "IList", "IList`1"));


### PR DESCRIPTION
this solves the issue where types metadata isn't including public functions from the base class, so you cannot mock them.
The example introduces a `Disposable` base and checks that the metadata for the method is contained in both the base and child classes