### PR TITLE
Feature/lower qualified names

### DIFF
--- a/src/DSharp.Compiler.Tests/Source/CompilerTests.json
+++ b/src/DSharp.Compiler.Tests/Source/CompilerTests.json
@@ -790,6 +790,11 @@
         "Name": "ArrayCreation",
         "SourceFiles": [ "Code.cs" ],
         "ComparisonFile": "Baseline.txt"
+      },
+      {
+        "Name": "FullyQualifiedTypes",
+        "SourceFiles": [ "Code.cs" ],
+        "ComparisonFile": "Baseline.txt"
       }
     ]
   }

--- a/src/DSharp.Compiler.Tests/Source/Lowering/FullyQualifiedTypes/Baseline.txt
+++ b/src/DSharp.Compiler.Tests/Source/Lowering/FullyQualifiedTypes/Baseline.txt
@@ -1,0 +1,38 @@
+"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+  // Some.Namespace.Bar
+
+  function Bar(bar) {
+  }
+
+
+  // Some.Namespace.Bar`1
+
+  function Bar_$1(t) {
+  }
+
+
+  // FullyQualifiedTypesTests.Foo
+
+  function Foo() {
+  }
+  var Foo$ = {
+    main: function() {
+      var bar = new Bar(new Bar());
+      var bart = ss.createGenericType(Bar_$1, {T : Bar}, new Bar());
+    }
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      Bar: ss.defineClass(Bar, null, [Bar], null),
+      Bar_$1: ss.defineClass(Bar_$1, null, [Object], null),
+      Foo: ss.defineClass(Foo, Foo$, [], null)
+    });
+
+
+  return $exports;
+});

--- a/src/DSharp.Compiler.Tests/Source/Lowering/FullyQualifiedTypes/Code.cs
+++ b/src/DSharp.Compiler.Tests/Source/Lowering/FullyQualifiedTypes/Code.cs
@@ -1,0 +1,37 @@
+﻿using System;
+#if X
+using OtherNamespace;
+#endif
+
+[assembly: ScriptAssembly("test")]
+
+namespace Some.Namespace
+{
+    public static class Bar
+    {
+        public Bar(Bar bar)
+        {
+
+        }
+    }
+
+    public static class Bar<T>
+    {
+        public Bar(T t)
+        {
+
+        }
+    }
+}
+
+namespace FullyQualifiedTypesTests
+{
+    public class Foo
+    {
+        public void Main()
+        {
+            Some.Namespace.Bar bar = new Some.Namespace.Bar(new Some.Namespace.Bar());
+            Some.Namespace.Bar<Some.Namespace.Bar> bart = new Some.Namespace.Bar<Some.Namespace.Bar>(new Some.Namespace.Bar());
+        }
+    }
+}

--- a/src/DSharp.Compiler/Preprocessing/Lowering/FullyQualifiedTypeNameRewriter.cs
+++ b/src/DSharp.Compiler/Preprocessing/Lowering/FullyQualifiedTypeNameRewriter.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace DSharp.Compiler.Preprocessing.Lowering
+{
+    public class FullyQualifiedTypeNameRewriter : CSharpSyntaxRewriter, ILowerer
+    {
+        private SemanticModel sem;
+        private HashSet<string> requiredUsings;
+
+        public CompilationUnitSyntax Apply(Compilation compilation, CompilationUnitSyntax root)
+        {
+            sem = compilation.GetSemanticModel(root.SyntaxTree);
+            requiredUsings = new HashSet<string>();
+
+            var newRoot = Visit(root) as CompilationUnitSyntax;
+
+            var missingUsings = requiredUsings.Where(r => !string.IsNullOrWhiteSpace(r)).Where(r => !root.Usings.Select(u => u.Name.ToString()).Contains(r));
+
+            if (missingUsings.Any())
+            {
+                var missingDirectives = missingUsings.Select(s => UsingDirective(ParseName(s).WithLeadingTrivia(Whitespace(" "))).WithTrailingTrivia(CarriageReturn)).ToArray();
+                newRoot = newRoot.AddUsings(missingDirectives);
+            }
+            return newRoot;
+        }
+
+        public override SyntaxNode VisitQualifiedName(QualifiedNameSyntax node)
+        {
+            var type = sem.GetTypeInfo(node).Type 
+                ?? sem.GetTypeInfo(node.Parent).Type;
+
+            if(type is INamedTypeSymbol && !node.Parent.IsKind(SyntaxKind.UsingDirective))
+            {
+                requiredUsings.Add(type.ContainingNamespace.ToString());
+                return Visit(node.Right)
+                    .WithTriviaFrom(node);
+            }
+
+            return node;
+        }
+    }
+}

--- a/src/DSharp.Compiler/ScriptCompiler.cs
+++ b/src/DSharp.Compiler/ScriptCompiler.cs
@@ -174,6 +174,7 @@ namespace DSharp.Compiler
                 new ImplicitArrayCreationRewriter(),
                 new OperatorOverloadRewriter(),
                 new ExtensionMethodToStaticRewriter(),
+                new FullyQualifiedTypeNameRewriter(),
             };
 
             compilation = CompilationPreprocessor.Preprocess(compilation, lowerers);


### PR DESCRIPTION
lowers uses of qualified names, uses type alias for non-generic types, and adds using directive for generic types (supporting alias for generic types will be more work)
the limitations of this approach are that qualified names cannot be used to resolve conflicts for generic types, however this is no worse than what is already implemented